### PR TITLE
[feature-18/feat] 관련 글 불러오기 & 구인, 구직 상세 페이지에서 스크랩  

### DIFF
--- a/src/domains/community/detail/components/RelatedPosts.jsx
+++ b/src/domains/community/detail/components/RelatedPosts.jsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react'
+import { getAllPosts } from '../../service/postService'
+import FreeBoard from '../../../../components/web/FreeBoard'
+import Spinner from '../../../../components/web/Spinner'
+const RelatedPosts = ({ currentId }) => {
+  const [posts, setPosts] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  useEffect(() => {
+    const fetchPosts = async () => {
+      try {
+        setLoading(true)
+        const allPostsData = await getAllPosts()
+        const boards = allPostsData.boards || []
+        const filtered = boards.filter((p) => String(p.boardId) !== String(currentId))
+        setPosts(filtered)
+      } catch (error) {
+        setError(error)
+        console.error('관련 글 불러오기 에러:', error)
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchPosts()
+  }, [currentId])
+
+  if (loading) {
+    return (
+      <div className='flex justify-center items-center h-[300px]'>
+        <Spinner size={48} color='main-pink' />
+      </div>
+    )
+  }
+
+  if (error) return <p className='text-red-500'>관련 글을 불러올 수 없습니다.</p>
+  if (posts.length === 0) return <p className='text-gray-400'>관련 글이 없습니다.</p>
+
+  return (
+    <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-10'>
+      {posts.map((post) => (
+        <div key={post.boardId} className='min-w-[300px]'>
+          <FreeBoard
+            boardId={post.boardId}
+            title={post.title}
+            content={post.text.replace(/<[^>]*>/g, '')}
+            name={post.nickname}
+            date={new Date(post.createdAt).toLocaleDateString()}
+            commentCount={post.commentCount}
+            viewCount={String(post.viewCount)}
+            onNameClick={(name) => {
+              console.log(`${name}의 게시글 보기`)
+            }}
+          />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default RelatedPosts

--- a/src/domains/community/detail/page/DetailCommunityPage.jsx
+++ b/src/domains/community/detail/page/DetailCommunityPage.jsx
@@ -14,7 +14,7 @@ import CommentForm from '../../comment/components/CommentForm'
 import CommentList from '../../comment/components/CommentList'
 import { deletePost, editPost } from '../../service/postService'
 import useCommentStore from '../../comment/store/useCommentStore'
-
+import RelatedPosts from '../components/RelatedPosts'
 const DetailCommunityPage = () => {
   const { user } = useAuthStore()
   const { id } = useParams()
@@ -142,7 +142,8 @@ const DetailCommunityPage = () => {
         <CommentForm boardId={id} onCommentAdded={() => fetchComments(id)} />
         {isCommentOpen && <CommentList boardId={id} />}
         <LastFormLine />
-        <h2 className='font-bold text-xl mb-4 flex self-start'>관련 글</h2>
+        <h2 className='font-bold text-xl my-5 flex self-start'>관련 글</h2>
+        <RelatedPosts currentId={id} />
       </div>
     </div>
   )

--- a/src/domains/job/main/page/JobMainPage.jsx
+++ b/src/domains/job/main/page/JobMainPage.jsx
@@ -124,9 +124,9 @@ const JobMainPage = () => {
           ) : displayedPosts.length > 0 ? (
             <JobPostList posts={displayedPosts} navigate={navigate} />
           ) : hasSearched ? (
-            <span>검색 결과가 없습니다.</span>
+            <p>검색 결과가 없습니다.</p>
           ) : (
-            <span>게시물이 없습니다.</span>
+            <p>게시물이 없습니다.</p>
           )}
         </div>
       </div>

--- a/src/domains/job/main/service/jobMainService.js
+++ b/src/domains/job/main/service/jobMainService.js
@@ -1,12 +1,12 @@
 // 구인 전체 글 조회 및 검색
 import { publicApi } from '../../../../services/api/axios'
-
 export const getAllRecruitmentPosts = async (lastId, order, keyword) => {
   try {
-    const params = { last: lastId, order }
-    if (keyword && keyword.trim() !== '') {
-      params.keyword = keyword
-    }
+    const params = {}
+    if (lastId !== undefined && lastId !== null) params.last = lastId
+    if (order !== undefined && order !== null) params.order = order
+    if (keyword && keyword.trim() !== '') params.keyword = keyword
+
     console.log('[구인 API 요청] params:', params)
 
     const response = await publicApi.get('/job-posting', {
@@ -16,7 +16,6 @@ export const getAllRecruitmentPosts = async (lastId, order, keyword) => {
         'Content-Type': 'application/json',
       },
     })
-
     console.log('[구인 API 응답 전체]', response)
 
     const data = response.data.data

--- a/src/domains/job/recruitment/detail/components/RelatedRecruitmentPosts.jsx
+++ b/src/domains/job/recruitment/detail/components/RelatedRecruitmentPosts.jsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { getAllRecruitmentPosts } from '../../../../job/main/service/jobMainService'
+import JobPostList from '../../../main/components/JobPostList'
+import Spinner from '../../../../../components/web/Spinner'
+
+const RecruitmentRelatedPosts = ({ currentId }) => {
+  const [posts, setPosts] = useState([])
+
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    const fetchPosts = async () => {
+      try {
+        setLoading(true)
+        const data = await getAllRecruitmentPosts(undefined, 'LATEST')
+        const jobPostings = data?.jobPostings || []
+        const filtered = jobPostings.filter((p) => String(p.id) !== String(currentId))
+        jobPostings.forEach((p) => console.log('post.id:', p.id))
+
+        setPosts(filtered)
+      } catch (err) {
+        setError(err)
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchPosts()
+  }, [currentId])
+
+  if (loading) {
+    return (
+      <div className='flex justify-center items-center h-[300px]'>
+        <Spinner size={48} color='main-pink' />
+      </div>
+    )
+  }
+
+  if (error) return <div className='text-red-500'>관련 채용 글을 불러올 수 없습니다.</div>
+  if (posts.length === 0) return <div className='text-gray-400'>관련 채용 글이 없습니다.</div>
+
+  console.log('currentId:', currentId)
+
+  return (
+    <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-10'>
+      <JobPostList posts={posts} navigate={navigate} />
+    </div>
+  )
+}
+
+export default RecruitmentRelatedPosts

--- a/src/domains/job/recruitment/detail/components/RelatedRecruitmentPosts.jsx
+++ b/src/domains/job/recruitment/detail/components/RelatedRecruitmentPosts.jsx
@@ -14,7 +14,7 @@ const RelatedRecruitmentPosts = ({ currentId }) => {
     let isMounted = true
     const fetchPosts = async () => {
       try {
-        if (isMounted) setLoading(true)
+        setLoading(true)
         const data = await getAllRecruitmentPosts(undefined, 'LATEST')
         const jobPostings = data?.jobPostings || []
         const filtered = jobPostings.filter((p) => String(p.id) !== String(currentId))

--- a/src/domains/job/recruitment/detail/components/RelatedRecruitmentPosts.jsx
+++ b/src/domains/job/recruitment/detail/components/RelatedRecruitmentPosts.jsx
@@ -6,28 +6,31 @@ import Spinner from '../../../../../components/web/Spinner'
 
 const RelatedRecruitmentPosts = ({ currentId }) => {
   const [posts, setPosts] = useState([])
-
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
   const navigate = useNavigate()
 
   useEffect(() => {
+    let isMounted = true
     const fetchPosts = async () => {
       try {
-        setLoading(true)
+        if (isMounted) setLoading(true)
         const data = await getAllRecruitmentPosts(undefined, 'LATEST')
         const jobPostings = data?.jobPostings || []
         const filtered = jobPostings.filter((p) => String(p.id) !== String(currentId))
         jobPostings.forEach((p) => console.log('post.id:', p.id))
 
-        setPosts(filtered)
+        if (isMounted) setPosts(filtered)
       } catch (err) {
-        setError(err)
+        if (isMounted) setError(err)
       } finally {
-        setLoading(false)
+        if (isMounted) setLoading(false)
       }
     }
     fetchPosts()
+    return () => {
+      isMounted = false
+    }
   }, [currentId])
 
   if (loading) {

--- a/src/domains/job/recruitment/detail/components/RelatedRecruitmentPosts.jsx
+++ b/src/domains/job/recruitment/detail/components/RelatedRecruitmentPosts.jsx
@@ -4,7 +4,7 @@ import { getAllRecruitmentPosts } from '../../../../job/main/service/jobMainServ
 import JobPostList from '../../../main/components/JobPostList'
 import Spinner from '../../../../../components/web/Spinner'
 
-const RecruitmentRelatedPosts = ({ currentId }) => {
+const RelatedRecruitmentPosts = ({ currentId }) => {
   const [posts, setPosts] = useState([])
 
   const [loading, setLoading] = useState(true)
@@ -50,4 +50,4 @@ const RecruitmentRelatedPosts = ({ currentId }) => {
   )
 }
 
-export default RecruitmentRelatedPosts
+export default RelatedRecruitmentPosts

--- a/src/domains/job/recruitment/detail/page/RecruitmentDetailPage.jsx
+++ b/src/domains/job/recruitment/detail/page/RecruitmentDetailPage.jsx
@@ -51,7 +51,7 @@ const RecruitmentDetailPage = () => {
   const handleScrapClick = async () => {
     try {
       await toggleScrap(id, 'JOB_POSTING')
-    } catch (e) {
+    } catch (error) {
       alert('스크랩 처리 중 오류가 발생했습니다.')
     }
   }

--- a/src/domains/job/recruitment/detail/page/RecruitmentDetailPage.jsx
+++ b/src/domains/job/recruitment/detail/page/RecruitmentDetailPage.jsx
@@ -2,7 +2,7 @@ import { useParams, useNavigate } from 'react-router-dom'
 import useRecruitmentPostDetail from '../hook/useRecruitmentPostDetail'
 import Spinner from '../../../../../components/web/Spinner'
 import unScrapIcon from '../../../../../assets/icons/common/common_bookmark_gray.svg'
-import ScrapIcon from '../../../../../assets/icons/common/common_bookmark_pink.svg' //아직 스크랩 적용 안 했음
+import ScrapIcon from '../../../../../assets/icons/common/common_bookmark_pink.svg'
 import DetailPostLine from '../../../common/components/DetailPostLine'
 import RelatedRecruitmentPosts from '../components/RelatedRecruitmentPosts'
 import { getJobCategoryLabel } from '../../../common/utils/jobCategories'
@@ -14,11 +14,13 @@ import share from '../../../../../assets/icons/common/common_share.svg'
 import { deleteRecruitmentPost } from '../../../common/service/postService'
 import ROUTER_PATHS from '../../../../../routes/RouterPath'
 import useAuthStore from '../../../../../store/login/useAuthStore'
+import useScrapStore from '../../../scrap/store/useScrapStore'
 const RecruitmentDetailPage = () => {
   const { user } = useAuthStore()
   const { id } = useParams()
   const { data, loading, error } = useRecruitmentPostDetail(id)
-
+  const { scraps, toggleScrap, loading: scrapLoading } = useScrapStore()
+  const isScrapped = Boolean(scraps[id])
   const navigate = useNavigate()
 
   if (loading) {
@@ -46,14 +48,26 @@ const RecruitmentDetailPage = () => {
     }
   }
 
+  const handleScrapClick = async () => {
+    try {
+      await toggleScrap(id, 'JOB_POSTING')
+    } catch (e) {
+      alert('스크랩 처리 중 오류가 발생했습니다.')
+    }
+  }
+
   return (
     <div className='px-4 md:px-12 lg:px-[100px] xl:px-[250px]'>
       <div className='flex items-center gap-2 justify-between'>
         <span className='font-semibold text-lg sm:text-xl md:text-2xl lg:text-[20px]'>
           {data.nickname}
         </span>
-        <button aria-label='스크랩'>
-          <img src={unScrapIcon} alt='스크랩 상태 아이콘' className='w-5 h-5' />
+        <button aria-label='스크랩' onClick={handleScrapClick} disabled={scrapLoading}>
+          <img
+            src={isScrapped ? ScrapIcon : unScrapIcon}
+            alt='스크랩 상태 아이콘'
+            className='w-5 h-5'
+          />
         </button>
       </div>
       <div className='flex justify-between mt-3'>

--- a/src/domains/job/recruitment/detail/page/RecruitmentDetailPage.jsx
+++ b/src/domains/job/recruitment/detail/page/RecruitmentDetailPage.jsx
@@ -4,6 +4,7 @@ import Spinner from '../../../../../components/web/Spinner'
 import unScrapIcon from '../../../../../assets/icons/common/common_bookmark_gray.svg'
 import ScrapIcon from '../../../../../assets/icons/common/common_bookmark_pink.svg' //아직 스크랩 적용 안 했음
 import DetailPostLine from '../../../common/components/DetailPostLine'
+import RelatedRecruitmentPosts from '../components/RelatedRecruitmentPosts'
 import { getJobCategoryLabel } from '../../../common/utils/jobCategories'
 import { getEmploymentTypeLabel } from '../../../common/utils/employmentTypes'
 import LastFormLine from '../../../common/components/LastFormLine'
@@ -108,7 +109,8 @@ const RecruitmentDetailPage = () => {
       </div>
       <div className='block mt-4 mb-10 whitespace-pre-line'>{data.text}</div>
       <LastFormLine />
-      <h2 className='font-bold text-xl mt-4 flex self-start'>관련 글</h2>
+      <h2 className='font-bold text-xl mt-7 flex self-start'>관련 글</h2>
+      <RelatedRecruitmentPosts currentId={id} />
     </div>
   )
 }

--- a/src/domains/job/search/detail/components/RelatedJobSearchPosts.jsx
+++ b/src/domains/job/search/detail/components/RelatedJobSearchPosts.jsx
@@ -12,21 +12,24 @@ const RelatedJobSearchPosts = ({ currentId }) => {
   const navigate = useNavigate()
 
   useEffect(() => {
+    let isMounted = true
     const fetchPosts = async () => {
       try {
-        setLoading(true)
+        if (isMounted) setLoading(true)
         const data = await getJobPosts(undefined, 'LATEST')
         const jobSeekings = data?.jobSeekings || []
         const filtered = jobSeekings.filter((p) => String(p.id) !== String(currentId))
-        jobSeekings.forEach((p) => console.log('post.id:', p.id))
-        setPosts(filtered)
+        if (isMounted) setPosts(filtered)
       } catch (err) {
-        setError(err)
+        if (isMounted) setError(err)
       } finally {
-        setLoading(false)
+        if (isMounted) setLoading(false)
       }
     }
     fetchPosts()
+    return () => {
+      isMounted = false
+    }
   }, [currentId])
 
   if (loading) {

--- a/src/domains/job/search/detail/components/RelatedJobSearchPosts.jsx
+++ b/src/domains/job/search/detail/components/RelatedJobSearchPosts.jsx
@@ -15,7 +15,7 @@ const RelatedJobSearchPosts = ({ currentId }) => {
     let isMounted = true
     const fetchPosts = async () => {
       try {
-        if (isMounted) setLoading(true)
+        setLoading(true)
         const data = await getJobPosts(undefined, 'LATEST')
         const jobSeekings = data?.jobSeekings || []
         const filtered = jobSeekings.filter((p) => String(p.id) !== String(currentId))

--- a/src/domains/job/search/detail/components/RelatedJobSearchPosts.jsx
+++ b/src/domains/job/search/detail/components/RelatedJobSearchPosts.jsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { getJobPosts } from '../../../../job/main/service/jobMainService'
+import JobPostList from '../../../main/components/JobPostList'
+import Spinner from '../../../../../components/web/Spinner'
+
+const RelatedJobSearchPosts = ({ currentId }) => {
+  const [posts, setPosts] = useState([])
+
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    const fetchPosts = async () => {
+      try {
+        setLoading(true)
+        const data = await getJobPosts(undefined, 'LATEST')
+        const jobSeekings = data?.jobSeekings || []
+        const filtered = jobSeekings.filter((p) => String(p.id) !== String(currentId))
+        jobSeekings.forEach((p) => console.log('post.id:', p.id))
+        setPosts(filtered)
+      } catch (err) {
+        setError(err)
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchPosts()
+  }, [currentId])
+
+  if (loading) {
+    return (
+      <div className='flex justify-center items-center h-[300px]'>
+        <Spinner size={48} color='main-pink' />
+      </div>
+    )
+  }
+
+  if (error) return <div className='text-red-500'>관련 채용 글을 불러올 수 없습니다.</div>
+  if (posts.length === 0) return <div className='text-gray-400'>관련 채용 글이 없습니다.</div>
+
+  return (
+    <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-10'>
+      <JobPostList posts={posts} navigate={navigate} />
+    </div>
+  )
+}
+
+export default RelatedJobSearchPosts

--- a/src/domains/job/search/detail/page/JobSeekDetailPage.jsx
+++ b/src/domains/job/search/detail/page/JobSeekDetailPage.jsx
@@ -50,7 +50,7 @@ const JobSeekDetailPage = () => {
 
   const handleScrapClick = async () => {
     try {
-      await toggleScrap(id, 'JOB_SEEKING') // type은 서버 명세에 맞게
+      await toggleScrap(id, 'JOB_SEEKING')
     } catch (e) {
       alert('스크랩 처리 중 오류가 발생했습니다.')
     }

--- a/src/domains/job/search/detail/page/JobSeekDetailPage.jsx
+++ b/src/domains/job/search/detail/page/JobSeekDetailPage.jsx
@@ -14,10 +14,13 @@ import share from '../../../../../assets/icons/common/common_share.svg'
 import { deleteJobSeekPost } from '../../../common/service/postService'
 import ROUTER_PATHS from '../../../../../routes/RouterPath'
 import RelatedJobSearchPosts from '../components/RelatedJobSearchPosts'
+import useScrapStore from '../../../scrap/store/useScrapStore'
 const JobSeekDetailPage = () => {
   const { user } = useAuthStore()
   const { id } = useParams()
   const { data, loading, error } = useJobSeekPostDetail(id)
+  const { scraps, toggleScrap, loading: scrapLoading } = useScrapStore()
+  const isScrapped = Boolean(scraps[id])
   const navigate = useNavigate()
 
   if (loading) {
@@ -45,12 +48,24 @@ const JobSeekDetailPage = () => {
     }
   }
 
+  const handleScrapClick = async () => {
+    try {
+      await toggleScrap(id, 'JOB_SEEKING') // type은 서버 명세에 맞게
+    } catch (e) {
+      alert('스크랩 처리 중 오류가 발생했습니다.')
+    }
+  }
+
   return (
     <div className='px-4 md:px-12 lg:px-[100px] xl:px-[250px]'>
       <div className='flex items-center gap-2 justify-between'>
         <strong className='text-lg'>{data.nickname}</strong>
-        <button aria-label='스크랩'>
-          <img src={unScrapIcon} alt='스크랩 상태 아이콘' className='w-5 h-5' />
+        <button aria-label='스크랩' onClick={handleScrapClick} disabled={scrapLoading}>
+          <img
+            src={isScrapped ? ScrapIcon : unScrapIcon}
+            alt='스크랩 상태 아이콘'
+            className='w-5 h-5'
+          />
         </button>
       </div>
       <div className='flex justify-between mt-3'>
@@ -90,7 +105,7 @@ const JobSeekDetailPage = () => {
       </div>
       <div className='block  mt-4 mb-10 whitespace-pre-line'>{data.text}</div>
       <LastFormLine />
-      <h2 className='font-bold text-xl mt-4 flex self-start'>관련 글</h2>
+      <h2 className='font-bold text-xl mt-7 flex self-start'>관련 글</h2>
       <RelatedJobSearchPosts currentId={id} />
     </div>
   )

--- a/src/domains/job/search/detail/page/JobSeekDetailPage.jsx
+++ b/src/domains/job/search/detail/page/JobSeekDetailPage.jsx
@@ -13,6 +13,7 @@ import viewPink from '../../../../../assets/icons/common/common_view_pink.svg'
 import share from '../../../../../assets/icons/common/common_share.svg'
 import { deleteJobSeekPost } from '../../../common/service/postService'
 import ROUTER_PATHS from '../../../../../routes/RouterPath'
+import RelatedJobSearchPosts from '../components/RelatedJobSearchPosts'
 const JobSeekDetailPage = () => {
   const { user } = useAuthStore()
   const { id } = useParams()
@@ -90,6 +91,7 @@ const JobSeekDetailPage = () => {
       <div className='block  mt-4 mb-10 whitespace-pre-line'>{data.text}</div>
       <LastFormLine />
       <h2 className='font-bold text-xl mt-4 flex self-start'>관련 글</h2>
+      <RelatedJobSearchPosts currentId={id} />
     </div>
   )
 }

--- a/src/domains/job/search/detail/page/JobSeekDetailPage.jsx
+++ b/src/domains/job/search/detail/page/JobSeekDetailPage.jsx
@@ -51,7 +51,8 @@ const JobSeekDetailPage = () => {
   const handleScrapClick = async () => {
     try {
       await toggleScrap(id, 'JOB_SEEKING')
-    } catch (e) {
+    } catch (error) {
+      console.error('스크랩 처리 중 오류:', error)
       alert('스크랩 처리 중 오류가 발생했습니다.')
     }
   }


### PR DESCRIPTION
## #️⃣연관된 이슈

#77 

### 📝작업 내용

- [x] 구인 상세페이지 스크랩
- [x] 구직 상세페이지 스크랩
- [x] 자유게시판 관련 글 불러오기
- [x] 구인 관련 글 불러오기 
- [x] 구직 관련 글 불러오기

### 📸 스크린샷 (선택)

**자유게시판 상세페이지 관련 글** 

<img width="1440" alt="스크린샷 2025-05-19 오후 2 10 40" src="https://github.com/user-attachments/assets/1431c3aa-91dc-41d8-b58e-33bac594f5cb" />

-----
**구인 상세페이지 관련 글**

<img width="1440" alt="스크린샷 2025-05-19 오후 2 10 53" src="https://github.com/user-attachments/assets/ec1afbd2-9322-40e0-a804-89ff60b01789" />

-----
**구직 상세페이지 관련 글**

<img width="1440" alt="스크린샷 2025-05-19 오후 2 12 57" src="https://github.com/user-attachments/assets/c093747e-6543-4596-aacc-fcd01d084e88" />


-----
**구인 & 구직 상세페이지 스크랩**

<img width="1440" alt="스크린샷 2025-05-19 오후 2 11 13" src="https://github.com/user-attachments/assets/dc59eba6-8d4e-4d0f-b24a-e17aba81b539" />

### 💬리뷰 요구사항(선택)

- 콘솔은 마지막에 지우겠습니다! 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 커뮤니티, 채용, 구직 상세 페이지에 관련 게시글(관련 커뮤니티 글, 관련 채용 공고, 관련 구직 글) 섹션이 추가되어 현재 게시글과 연관된 다른 글을 확인할 수 있습니다.
  - 채용 및 구직 상세 페이지에서 스크랩(북마크) 기능이 추가되어, 게시글을 스크랩하거나 스크랩 해제할 수 있습니다.

- **스타일**
  - 채용 메인 페이지에서 검색 결과 또는 게시물이 없을 때 안내 문구의 HTML 태그가 `<span>`에서 `<p>`로 변경되었습니다.

- **버그 수정**
  - 채용 공고 목록 조회 시, 불필요한 쿼리 파라미터가 API 요청에 포함되지 않도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->