### PR TITLE
[feature-22/feat] 비회원이 상세페이지 진입시에 로그인 페이지로 라우팅 걸어주기 & 스크랩하면 toastify 띄워주기 완료 

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,11 +7,9 @@ import { ToastContainer } from 'react-toastify'
 import 'react-toastify/dist/ReactToastify.css'
 
 function App() {
-  const initialize = useAuthStore((state) => state.initialize)
-
   useEffect(() => {
-    initialize()
-  }, [initialize])
+    useAuthStore.getState().initialize()
+  }, [])
 
   return (
     <BrowserRouter>

--- a/src/components/app/MobileWorkBoard.jsx
+++ b/src/components/app/MobileWorkBoard.jsx
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types'
+import { useState } from 'react'
 import joboffer from '../../assets/icons/common/common_tag_ joboffer.svg'
 import history from '../../assets/icons/common/common_tag_history.svg'
 import jobsearch from '../../assets/icons/common/common_tag_jobsearch.svg'
@@ -12,7 +13,8 @@ import TagIcon from '../web/TagIcon'
 import MobileShare from './MobileShare'
 import useScrapStore from '../../domains/job/scrap/store/useScrapStore'
 import { employmentTypes } from '../../domains/job/common/utils/employmentTypes'
-
+import LoginRequiredAlert from '../common/LoginRequiredAlert'
+import useAuthStore from '../../store/login/useAuthStore'
 const getEmploymentLabel = (value) => {
   const found = employmentTypes.find((item) => item.value === value)
   return found ? found.label : value
@@ -40,54 +42,64 @@ const MobileWorkBoard = ({
   const loading = useScrapStore((state) => state.loading)
   const toggleScrap = useScrapStore((state) => state.toggleScrap)
 
+  const { isAuthenticated } = useAuthStore()
+  const [showLoginAlert, setShowLoginAlert] = useState(false)
+
   const scrapped = Boolean(scraps[postId])
   const bookmarkIcon = scrapped ? bookmarkPink : bookmarkGray
 
-  const handleToggleScrap = (e) => {
-    e.stopPropagation()
+  const handleToggleScrap = () => {
+    if (!isAuthenticated) {
+      setShowLoginAlert(true)
+      return
+    }
     toggleScrap(postId, type)
   }
-
   return (
-    <div
-      className={`w-full max-w-xs mx-auto mt-3 ${className || ''}`}
-      onClick={onClick}
-      style={{ cursor: 'pointer' }}
-    >
-      <div className='relative flex flex-col h-auto border border-light-gray rounded-[10px] px-5 pt-5 pb-4 justify-between bg-white shadow-sm'>
-        <button
-          className='absolute top-[-2px] right-4 z-10 p-0 bg-transparent border-none'
-          onClick={handleToggleScrap}
-          disabled={loading}
-          aria-label={scrapped ? '스크랩 해제' : '스크랩'}
-        >
-          <img
-            src={bookmarkIcon}
-            alt='스크랩 아이콘'
-            className='w-6 h-6'
-            style={{ opacity: loading ? 0.5 : 1 }}
-          />
-        </button>
+    <>
+      <div
+        className={`w-full max-w-xs mx-auto mt-3 ${className || ''}`}
+        onClick={onClick}
+        style={{ cursor: 'pointer' }}
+      >
+        <div className='relative flex flex-col h-auto border border-light-gray rounded-[10px] px-5 pt-5 pb-4 justify-between bg-white shadow-sm'>
+          <button
+            className='absolute top-[-2px] right-4 z-10 p-0 bg-transparent border-none'
+            onClick={handleToggleScrap}
+            disabled={loading}
+            aria-label={scrapped ? '스크랩 해제' : '스크랩'}
+          >
+            <img
+              src={bookmarkIcon}
+              alt='스크랩 아이콘'
+              className='w-6 h-6'
+              style={{ opacity: loading ? 0.5 : 1 }}
+            />
+          </button>
 
-        <div className='flex flex-wrap gap-1 mb-2'>
-          {popular1 && <TagIcon label='인기 글' icon={popular} />}
-          {joboffer1 && <TagIcon label='구인' icon={joboffer} />}
-          {experienceLabel && <TagIcon label={experienceLabel} icon={history} />}
-          {jobsearch1 && <TagIcon label='구직' icon={jobsearch} />}
-          {othersite1 && <TagIcon label='외부 사이트' icon={othersite} />}
-          {employmentType && <TagIcon label={getEmploymentLabel(employmentType)} icon={worktype} />}
-        </div>
-        <h3 className='text-base sm:text-lg font-bold line-clamp-2 mb-2 self-start'>{title}</h3>
-        <div className='flex flex-col text-dark-gray text-xs sm:text-sm mt-auto'>
-          <div className='flex justify-end font-bold mb-1'>{name}</div>
-          <hr className='my-1 border-dark-gray' />
-          <div className='flex items-end justify-between'>
-            <span>{date}</span>
-            <MobileShare label={view} textColor='text-main-pink' icon={viewPink} />
+          <div className='flex flex-wrap gap-1 mb-2'>
+            {popular1 && <TagIcon label='인기 글' icon={popular} />}
+            {joboffer1 && <TagIcon label='구인' icon={joboffer} />}
+            {experienceLabel && <TagIcon label={experienceLabel} icon={history} />}
+            {jobsearch1 && <TagIcon label='구직' icon={jobsearch} />}
+            {othersite1 && <TagIcon label='외부 사이트' icon={othersite} />}
+            {employmentType && (
+              <TagIcon label={getEmploymentLabel(employmentType)} icon={worktype} />
+            )}
+          </div>
+          <h3 className='text-base sm:text-lg font-bold line-clamp-2 mb-2 self-start'>{title}</h3>
+          <div className='flex flex-col text-dark-gray text-xs sm:text-sm mt-auto'>
+            <div className='flex justify-end font-bold mb-1'>{name}</div>
+            <hr className='my-1 border-dark-gray' />
+            <div className='flex items-end justify-between'>
+              <span>{date}</span>
+              <MobileShare label={view} textColor='text-main-pink' icon={viewPink} />
+            </div>
           </div>
         </div>
       </div>
-    </div>
+      <LoginRequiredAlert isOpen={showLoginAlert} onClose={() => setShowLoginAlert(false)} />
+    </>
   )
 }
 

--- a/src/components/app/MobileWorkBoard.jsx
+++ b/src/components/app/MobileWorkBoard.jsx
@@ -15,6 +15,7 @@ import useScrapStore from '../../domains/job/scrap/store/useScrapStore'
 import { employmentTypes } from '../../domains/job/common/utils/employmentTypes'
 import LoginRequiredAlert from '../common/LoginRequiredAlert'
 import useAuthStore from '../../store/login/useAuthStore'
+import ToastService from '../../utils/toastService'
 const getEmploymentLabel = (value) => {
   const found = employmentTypes.find((item) => item.value === value)
   return found ? found.label : value
@@ -47,13 +48,22 @@ const MobileWorkBoard = ({
 
   const scrapped = Boolean(scraps[postId])
   const bookmarkIcon = scrapped ? bookmarkPink : bookmarkGray
-
-  const handleToggleScrap = () => {
+  const handleToggleScrap = async () => {
     if (!isAuthenticated) {
       setShowLoginAlert(true)
       return
     }
-    toggleScrap(postId, type)
+    try {
+      await toggleScrap(postId, type)
+      const nowScrapped = Boolean(useScrapStore.getState().scraps[postId])
+      if (nowScrapped) {
+        ToastService.success('스크랩되었습니다.')
+      } else {
+        ToastService.info('스크랩이 해제되었습니다.')
+      }
+    } catch (error) {
+      ToastService.error('스크랩 처리 중 오류가 발생했습니다.')
+    }
   }
   return (
     <>

--- a/src/components/common/LoginRequiredAlert.jsx
+++ b/src/components/common/LoginRequiredAlert.jsx
@@ -1,0 +1,25 @@
+import { useNavigate } from 'react-router-dom'
+import Alert from '../web/Alert'
+import ROUTER_PATHS from '../../routes/RouterPath'
+
+const LoginRequiredAlert = ({ isOpen, onClose }) => {
+  const navigate = useNavigate()
+
+  const handleLogin = () => {
+    onClose()
+    navigate(ROUTER_PATHS.LOGIN_MAIN, { replace: true })
+  }
+
+  return (
+    <Alert
+      isOpen={isOpen}
+      onClose={onClose}
+      title='로그인이 필요합니다'
+      description='로그인이 필요한 기능입니다. 로그인 페이지로 이동하시겠습니까?'
+      buttonLabel='로그인하기'
+      onButtonClick={handleLogin}
+    />
+  )
+}
+
+export default LoginRequiredAlert

--- a/src/components/common/ScrollAndWriteButton.jsx
+++ b/src/components/common/ScrollAndWriteButton.jsx
@@ -34,7 +34,7 @@ const ScrollBtn = () => {
   const btnBaseClass =
     'w-[52px] h-[52px] sm:w-[60px] sm:h-[60px] flex items-center justify-center ' +
     'rounded-full backdrop-blur-md bg-white/30 border border-light-gray shadow-lg ' +
-    'hover:scale-110 transition-transform duration-200 z-[9999]'
+    'hover:scale-110 transition-transform duration-200 z-100'
 
   return (
     <>

--- a/src/components/web/WorkBoard.jsx
+++ b/src/components/web/WorkBoard.jsx
@@ -15,6 +15,7 @@ import useScrapStore from '../../domains/job/scrap/store/useScrapStore'
 import { employmentTypes } from '../../domains/job/common/utils/employmentTypes'
 import LoginRequiredAlert from '../common/LoginRequiredAlert'
 import useAuthStore from '../../store/login/useAuthStore'
+import ToastService from '../../utils/toastService'
 const getEmploymentLabel = (value) => {
   const found = employmentTypes.find((item) => item.value === value)
   return found ? found.label : value
@@ -44,14 +45,23 @@ const WorkBoard = ({
   const scrapped = Boolean(scraps[postId])
   const bookmarkIcon = scrapped ? bookmarkPink : bookmarkGray
 
-  const handleToggleScrap = () => {
+  const handleToggleScrap = async () => {
     if (!isAuthenticated) {
       setShowLoginAlert(true)
       return
     }
-    toggleScrap(postId, type)
+    try {
+      await toggleScrap(postId, type)
+      const nowScrapped = Boolean(useScrapStore.getState().scraps[postId])
+      if (nowScrapped) {
+        ToastService.success('스크랩되었습니다.')
+      } else {
+        ToastService.info('스크랩이 해제되었습니다.')
+      }
+    } catch (error) {
+      ToastService.error('스크랩 처리 중 오류가 발생했습니다.')
+    }
   }
-
   return (
     <>
       <div className='w-full h-[200px] mb-3 mt-3 relative'>

--- a/src/components/web/WorkBoard.jsx
+++ b/src/components/web/WorkBoard.jsx
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types'
+import { useState } from 'react'
 import joboffer from '../../assets/icons/common/common_tag_ joboffer.svg'
 import history from '../../assets/icons/common/common_tag_history.svg'
 import jobsearch from '../../assets/icons/common/common_tag_jobsearch.svg'
@@ -12,12 +13,12 @@ import TagIcon from './TagIcon'
 import ShareViews from './ShareViews'
 import useScrapStore from '../../domains/job/scrap/store/useScrapStore'
 import { employmentTypes } from '../../domains/job/common/utils/employmentTypes'
-
+import LoginRequiredAlert from '../common/LoginRequiredAlert'
+import useAuthStore from '../../store/login/useAuthStore'
 const getEmploymentLabel = (value) => {
   const found = employmentTypes.find((item) => item.value === value)
   return found ? found.label : value
 }
-
 const WorkBoard = ({
   title,
   name,
@@ -37,54 +38,66 @@ const WorkBoard = ({
   const loading = useScrapStore((state) => state.loading)
   const toggleScrap = useScrapStore((state) => state.toggleScrap)
 
+  const { isAuthenticated } = useAuthStore()
+  const [showLoginAlert, setShowLoginAlert] = useState(false)
+
   const scrapped = Boolean(scraps[postId])
   const bookmarkIcon = scrapped ? bookmarkPink : bookmarkGray
 
   const handleToggleScrap = () => {
+    if (!isAuthenticated) {
+      setShowLoginAlert(true)
+      return
+    }
     toggleScrap(postId, type)
   }
 
   return (
-    <div className='w-full h-[200px] mb-3 mt-3 relative'>
-      <button
-        className='absolute top-[-2px] right-3 z-10 bg-transparent border-none p-0'
-        onClick={handleToggleScrap}
-        aria-label={scrapped ? '스크랩 해제' : '스크랩'}
-      >
-        <img
-          src={bookmarkIcon}
-          alt='북마크'
-          className='w-6 h-6'
-          style={{ opacity: loading ? 0.5 : 1 }}
-        />
-      </button>
-      <div className='flex flex-col h-full border border-[#D6D6D6] rounded-[10px] px-[18px] pt-[15px] pb-[10px] justify-between cursor-pointer'>
-        <div className='flex flex-wrap gap-2 mb-2'>
-          {popular1 && <TagIcon label='인기 글' icon={popular} />}
-          {joboffer1 && <TagIcon label='구인' icon={joboffer} />}
-          {experienceLabel && <TagIcon label={experienceLabel} icon={history} />}
-          {jobsearch1 && <TagIcon label='구직' icon={jobsearch} />}
-          {othersite1 && <TagIcon label='외부 사이트' icon={othersite} />}
-          {employmentType && <TagIcon label={getEmploymentLabel(employmentType)} icon={worktype} />}
-        </div>
-        <h3
-          onClick={onClick}
-          className='flex font-bold line-clamp-2 text-sm sm:text-base md:text-lg mb-1'
+    <>
+      <div className='w-full h-[200px] mb-3 mt-3 relative'>
+        <button
+          className='absolute top-[-2px] right-3 z-10 bg-transparent border-none p-0'
+          onClick={handleToggleScrap}
+          aria-label={scrapped ? '스크랩 해제' : '스크랩'}
         >
-          {title}
-        </h3>
-        <div className='flex-row text-dark-gray text-xs sm:text-sm md:text-base'>
-          <div onClick={onClick} className='flex justify-end font-bold'>
-            {name}
+          <img
+            src={bookmarkIcon}
+            alt='북마크'
+            className='w-6 h-6'
+            style={{ opacity: loading ? 0.5 : 1 }}
+          />
+        </button>
+        <div className='flex flex-col h-full border border-[#D6D6D6] rounded-[10px] px-[18px] pt-[15px] pb-[10px] justify-between cursor-pointer'>
+          <div className='flex flex-wrap gap-2 mb-2'>
+            {popular1 && <TagIcon label='인기 글' icon={popular} />}
+            {joboffer1 && <TagIcon label='구인' icon={joboffer} />}
+            {experienceLabel && <TagIcon label={experienceLabel} icon={history} />}
+            {jobsearch1 && <TagIcon label='구직' icon={jobsearch} />}
+            {othersite1 && <TagIcon label='외부 사이트' icon={othersite} />}
+            {employmentType && (
+              <TagIcon label={getEmploymentLabel(employmentType)} icon={worktype} />
+            )}
           </div>
-          <hr className='my-1 border-dark-gray' />
-          <div className='flex items-end justify-between'>
-            <span>{date}</span>
-            <ShareViews label={view} textColor='text-main-pink' icon={viewPink} />
+          <h3
+            onClick={onClick}
+            className='flex font-bold line-clamp-2 text-sm sm:text-base md:text-lg mb-1'
+          >
+            {title}
+          </h3>
+          <div className='flex-row text-dark-gray text-xs sm:text-sm md:text-base'>
+            <div onClick={onClick} className='flex justify-end font-bold'>
+              {name}
+            </div>
+            <hr className='my-1 border-dark-gray' />
+            <div className='flex items-end justify-between'>
+              <span>{date}</span>
+              <ShareViews label={view} textColor='text-main-pink' icon={viewPink} />
+            </div>
           </div>
         </div>
       </div>
-    </div>
+      <LoginRequiredAlert isOpen={showLoginAlert} onClose={() => setShowLoginAlert(false)} />
+    </>
   )
 }
 

--- a/src/domains/community/write/page/WriteCommunityPostPage.jsx
+++ b/src/domains/community/write/page/WriteCommunityPostPage.jsx
@@ -2,19 +2,9 @@ import WriteFormLine from '../../../../components/web/WriteFormLine'
 import LastFormLine from '../../../job/common/components/LastFormLine'
 import Button from '../../../../components/web/Button'
 import WriteCommunityPostForm from '../components/WriteCommunityPostForm'
-import useAuthStore from '../../../../store/login/useAuthStore'
-import { useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
 import PinkButton from '../../../../components/web/PinkButton'
 
 const WriteCommunityPost = () => {
-  const navigate = useNavigate()
-  const { requireLogin } = useAuthStore()
-
-  useEffect(() => {
-    requireLogin(navigate)
-  }, [requireLogin, navigate])
-
   return (
     <main className='flex flex-col gap-4 max-w-[1440px] w-full px-4 sm:px-10 lg:px-[250px] mx-auto'>
       <h1 className='hidden sm:block text-3xl font-bold self-start mt-[50px]'>

--- a/src/domains/job/recruitment/write/page/WriteRecruitmentPostPage.jsx
+++ b/src/domains/job/recruitment/write/page/WriteRecruitmentPostPage.jsx
@@ -3,22 +3,10 @@ import LastFormLine from '../../../common/components/LastFormLine'
 import Button from '../../../../../components/web/Button'
 import PinkButton from '../../../../../components/web/PinkButton'
 import WriteRecruitmentPostingForm from '../../components/WriteRecruitmentPostingForm'
-import useAuthStore from '../../../../../store/login/useAuthStore'
-import { useNavigate } from 'react-router-dom'
 import { createRecruitmentPost } from '../../../common/service/postService'
-import { useEffect } from 'react'
 import { usePostSubmit } from '../../../common/hook/usePostSubmit'
 const WriteRecruitmentPostPage = () => {
-  const navigate = useNavigate()
-  const { requireLogin, isAuthenticated } = useAuthStore()
   const handleSubmitForm = usePostSubmit(createRecruitmentPost)
-
-  useEffect(() => {
-    if (!isAuthenticated) {
-      requireLogin(navigate)
-    }
-  }, [requireLogin, navigate, isAuthenticated])
-
   return (
     <>
       <div className='flex flex-col gap-4 max-w-[1440px] w-full px-4 sm:px-10 lg:px-[250px] mx-auto'>

--- a/src/domains/job/search/write/page/WriteJobSearchPostPage.jsx
+++ b/src/domains/job/search/write/page/WriteJobSearchPostPage.jsx
@@ -3,23 +3,11 @@ import WriteJobSearchPostingForm from '../../components/WriteJobSearchPostingFor
 import LastFormLine from '../../../common/components/LastFormLine'
 import Button from '../../../../../components/web/Button'
 import PinkButton from '../../../../../components/web/PinkButton'
-import { useNavigate } from 'react-router-dom'
-import { useEffect } from 'react'
-import useAuthStore from '../../../../../store/login/useAuthStore'
 import { createJobSeekPost } from '../../../common/service/postService'
 import { usePostSubmit } from '../../../common/hook/usePostSubmit'
 
 const WriteJobSearchPostPage = () => {
-  const navigate = useNavigate()
-  const { requireLogin, isAuthenticated } = useAuthStore()
   const handleSubmitForm = usePostSubmit(createJobSeekPost)
-
-  useEffect(() => {
-    if (!isAuthenticated) {
-      requireLogin(navigate)
-    }
-  }, [requireLogin, navigate, isAuthenticated])
-
   return (
     <>
       <div className='flex flex-col gap-4 max-w-[1440px] w-full px-4 sm:px-10 lg:px-[250px] mx-auto'>

--- a/src/domains/my/page/MyPage.jsx
+++ b/src/domains/my/page/MyPage.jsx
@@ -2,17 +2,12 @@ import { useEffect, useState } from 'react'
 import MyActivity from '../mypage/components/MyActivity'
 import MyData from '../mypage/components/MyData'
 import { getMyData } from '../services/userMyDataServices'
-import useAuthStore from '../../../store/login/useAuthStore'
-import { useNavigate } from 'react-router-dom'
 import Spinner from '../../../components/web/Spinner'
 
 const MyPage = () => {
   const [userData, setUserData] = useState()
-  const { requireLogin, isAuthenticated } = useAuthStore()
-  const [isLoading, setIsLoading] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState(null)
-  const navigate = useNavigate()
-
 
   const handleMyData = async () => {
     try {
@@ -33,11 +28,8 @@ const MyPage = () => {
   }
 
   useEffect(() => {
-    requireLogin(navigate);
-    if (isAuthenticated) {
-      handleMyData();
-    }
-  }, [requireLogin, navigate, isAuthenticated]);
+    handleMyData()
+  }, [])
 
   return (
     <div>

--- a/src/routes/AppRoutes.jsx
+++ b/src/routes/AppRoutes.jsx
@@ -1,21 +1,21 @@
-import { useEffect } from 'react'
 import { Route, Routes } from 'react-router-dom'
 import routes from './routes'
 import Layout from './Layout'
-import useAuthStore from '../store/login/useAuthStore'
+import ProtectedRoute from './ProtectedRoute'
 
 const AppRoutes = () => {
   const mainPaths = ['/', '/community', '/user-post', '/job']
-  const initialize = useAuthStore((state) => state.initialize)
-
-  useEffect(() => {
-    initialize()
-  }, [])
 
   return (
     <Routes>
       {routes.map((route, index) => {
         const isMain = mainPaths.includes(route.path)
+
+        const content = route.isProtected ? (
+          <ProtectedRoute>{route.element}</ProtectedRoute>
+        ) : (
+          route.element
+        )
 
         return (
           <Route
@@ -27,7 +27,7 @@ const AppRoutes = () => {
                 label={route.label}
                 noMargin={route.noMargin}
               >
-                {route.element}
+                {content}
               </Layout>
             }
           />

--- a/src/routes/ProtectedRoute.jsx
+++ b/src/routes/ProtectedRoute.jsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import useAuthStore from '../store/login/useAuthStore'
+import ROUTER_PATHS from './RouterPath'
+import Alert from '../components/web/Alert'
+
+const ProtectedRoute = ({ children }) => {
+  const { isAuthenticated } = useAuthStore()
+  const navigate = useNavigate()
+  const [showAlert, setShowAlert] = useState(false)
+  const [checked, setChecked] = useState(false)
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setShowAlert(true)
+    } else {
+      setChecked(true)
+    }
+  }, [isAuthenticated])
+
+  const handleAlertClose = () => {
+    setShowAlert(false)
+    setChecked(true)
+  }
+
+  const handleAlertAction = () => {
+    navigate(ROUTER_PATHS.LOGIN_MAIN, { replace: true })
+  }
+
+  if (!checked && !showAlert) return null
+
+  return (
+    <>
+      {isAuthenticated ? children : null}
+      <Alert
+        isOpen={showAlert}
+        onClose={handleAlertClose}
+        title='로그인이 필요합니다'
+        description='로그인이 필요한 페이지입니다. 로그인 페이지로 이동하시겠습니까?'
+        buttonLabel='로그인하기'
+        onButtonClick={handleAlertAction}
+      />
+    </>
+  )
+}
+
+export default ProtectedRoute

--- a/src/routes/RouterPath.js
+++ b/src/routes/RouterPath.js
@@ -5,15 +5,15 @@ const ROUTER_PATHS = {
   MEMBER_DATA_ENTRY: '/member-data-entry',
   JOB_MAIN: '/job',
   COMMUNITY: '/community',
-  USER_POST: '/user-post', //특정 사용자가 작성한 글
-  WRITE_COMMUNITY_POST: '/community/post', //자유게시판 글 작성
-  COMMUNITY_POST_DETAIL: '/community/post/:id', //자유게시판 글 상세페이지
-  WRITE_RECRUITMENT_POST: '/job/recruitment/post', //구인 글 작성
-  WRITE_JOB_SEARCH_POST: '/job/job-search/post', //구직 글 작성
-  JOB_SEARCH_POST_EDIT: '/job/job-seek/edit/:id', //구직 글 수정
-  JOB_SEARCH_POST_DETAIL: '/job/job-seek/post/:id', //구직 글 상세 조회
-  RECRUITMENT_POST_DETAIL: '/job/recruitment/post/:id', //구인 글 상세 조회
-  RECRUITMENT_POST_EDIT: '/job/recruitment/edit/:id', //구인 글 수정
+  USER_POST: '/user-post',
+  WRITE_COMMUNITY_POST: '/community/post',
+  COMMUNITY_POST_DETAIL: '/community/post/:id',
+  WRITE_RECRUITMENT_POST: '/job/recruitment/post',
+  WRITE_JOB_SEARCH_POST: '/job/job-search/post',
+  JOB_SEARCH_POST_EDIT: '/job/job-seek/edit/:id',
+  JOB_SEARCH_POST_DETAIL: '/job/job-seek/post/:id',
+  RECRUITMENT_POST_DETAIL: '/job/recruitment/post/:id',
+  RECRUITMENT_POST_EDIT: '/job/recruitment/edit/:id',
   FIND_ID: '/find/id', // 아이디 찾기 페이지
   FIND_ID_COMPLETE_PAGE: '/find/id/complete-page',
   FIND_PW: '/find/pw', //비밀번호 찾기 페이지

--- a/src/routes/routes.jsx
+++ b/src/routes/routes.jsx
@@ -54,10 +54,12 @@ const routes = [
     path: ROUTER_PATHS.WRITE_COMMUNITY_POST,
     element: <WriteCommunityPostPage />,
     label: '자유게시판 글 작성',
+    isProtected: true,
   },
   {
     path: '/community/post/:id',
     element: <DetailCommunityPage />,
+    isProtected: true,
   },
   {
     path: ROUTER_PATHS.USER_POST,
@@ -73,31 +75,37 @@ const routes = [
     path: ROUTER_PATHS.WRITE_RECRUITMENT_POST,
     element: <WriteRecruitmentPostPage />,
     label: '구인 글 작성',
+    isProtected: true,
   },
   {
     path: '/job/recruitment/post/:id',
     element: <RecruitmentDetailPage />,
     label: '구인 상세 글',
+    isProtected: true,
   },
   {
     path: '/job/recruitment/edit/:id',
     element: <EditRecruitmentPost />,
     label: '구인 글 수정',
+    isProtected: true,
   },
   {
     path: ROUTER_PATHS.WRITE_JOB_SEARCH_POST,
     element: <WriteJobSearchPostPage />,
     label: '구직 글 작성',
+    isProtected: true,
   },
   {
     path: '/job/job-seek/edit/:id',
     element: <EditJobSeekPostPage />,
     label: '구직 글 수정',
+    isProtected: true,
   },
   {
     path: '/job/job-seek/post/:id',
     element: <JobSeekDetailPage />,
     label: '구직 상세 글',
+    isProtected: true,
   },
   {
     path: ROUTER_PATHS.FIND_ID,
@@ -143,6 +151,7 @@ const routes = [
     path: ROUTER_PATHS.MY_PAGE,
     element: <MyPage />,
     noMargin: true,
+    isProtected: true,
   },
   {
     path: ROUTER_PATHS.MY_EDIT_PROFILE,


### PR DESCRIPTION
## #️⃣연관된 이슈

#94 

### 📝작업 내용


### 📸 스크린샷 (선택)

**비회원 특정 페이지 진입시 막기**
<img width="1440" alt="스크린샷 2025-05-28 오후 3 41 57" src="https://github.com/user-attachments/assets/ce3f157a-e7f0-437e-9b81-4181a9fa53a2" />

---
**스크랩 Toastify 적용**
<img width="1440" alt="스크린샷 2025-05-28 오후 3 47 40" src="https://github.com/user-attachments/assets/4275d6dd-09c9-4c69-8d7f-ed8516ece0fa" />

### 💬리뷰 요구사항(선택)
`[ProtectedRoute.jsx]` 컴포넌트 만들어뒀습니다! 비회원 특정 페이지 접근 막는 건 페이지마다 적용하지 말고    

```jsx
path: ROUTER_PATHS.WRITE_COMMUNITY_POST,
    element: <WriteCommunityPostPage />,
    label: '자유게시판 글 작성',
    isProtected: true,
  },
```
이런식으로 ` isProtected: true`만 넣어주면 됩니다! 마이페이지에는 적용해뒀어요