### PR TITLE
[publishing-22/style] 퍼블리싱 수정 

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,7 +20,15 @@ function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
-        <ToastContainer position='top-center' autoClose={2000} theme='colored' />
+        <ToastContainer
+          position='bottom-center'
+          autoClose={2000}
+          theme='colored'
+          toastClassName='!rounded-xl !shadow-md !p-4 !text-sm w-full max-w-[360px] mx-auto'
+          bodyClassName='text-sm font-semibold'
+          hideProgressBar={true}
+          style={{ marginBottom: '60px' }}
+        />
         <PageScrollToTop />
         <AppRoutes />
         <ReactQueryDevtools initialIsOpen={false} />

--- a/src/components/app/MobileFreeBoard.jsx
+++ b/src/components/app/MobileFreeBoard.jsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom'
 import viewPink from '../../assets/icons/common/common_view_pink.svg'
 import comment from '../../assets/icons/common/comment.svg'
 import MobileShare from './MobileShare'
+import { BsCardImage } from 'react-icons/bs'
 
 const MobileFreeBoard = ({
   boardId,
@@ -14,6 +15,7 @@ const MobileFreeBoard = ({
   onClick,
   commentCount,
   viewCount,
+  isImagePost,
 }) => {
   const [showButton, setShowButton] = useState(false)
   const navigate = useNavigate()
@@ -37,7 +39,16 @@ const MobileFreeBoard = ({
       <div className='flex flex-col h-full  border border-light-gray rounded-[10px] px-[20px] pt-[20px] pb-[16px] justify-between cursor-pointer text-left'>
         <div className='flex-row' onClick={onClick}>
           <div className='text-[18px] font-bold line-clamp-1'>{title}</div>
-          <div className='mt-[5px] text-[14px] line-clamp-1'>{content}</div>
+          <div className='mt-2 text-sm sm:text-base line-clamp-1'>
+            {isImagePost ? (
+              <span className='flex items-center gap-1 text-gray-500'>
+                <BsCardImage className='text-lg' />
+                이미지 게시글입니다
+              </span>
+            ) : (
+              content
+            )}
+          </div>
         </div>
         <div className='flex-row  text-dark-gray text-[14px]'>
           <div onClick={onClick} className='flex justify-between font-bold '>

--- a/src/components/web/FreeBoard.jsx
+++ b/src/components/web/FreeBoard.jsx
@@ -4,8 +4,19 @@ import { useNavigate } from 'react-router-dom'
 import viewPink from '../../assets/icons/common/common_view_pink.svg'
 import comment from '../../assets/icons/common/comment.svg'
 import ShareViews from './ShareViews'
+import { BsCardImage } from 'react-icons/bs'
 
-const FreeBoard = ({ boardId, title, content, name, date, onClick, commentCount, viewCount }) => {
+const FreeBoard = ({
+  boardId,
+  title,
+  content,
+  name,
+  date,
+  onClick,
+  commentCount,
+  viewCount,
+  isImagePost,
+}) => {
   const [showButton, setShowButton] = useState(false)
   const navigate = useNavigate()
 
@@ -44,7 +55,16 @@ const FreeBoard = ({ boardId, title, content, name, date, onClick, commentCount,
       >
         <div className='flex flex-col items-start text-left' onClick={onClick}>
           <div className='text-base font-bold truncate sm:text-lg'>{title}</div>
-          <div className='mt-2 text-sm sm:text-base line-clamp-1'>{content}</div>
+          <div className='mt-2 text-sm sm:text-base line-clamp-1'>
+            {isImagePost ? (
+              <span className='flex items-center gap-1 text-gray-500'>
+                <BsCardImage className='text-lg' />
+                이미지 게시글입니다
+              </span>
+            ) : (
+              content
+            )}
+          </div>
         </div>
 
         <div className='mt-4 text-xs text-dark-gray sm:text-sm'>
@@ -81,11 +101,12 @@ const FreeBoard = ({ boardId, title, content, name, date, onClick, commentCount,
 FreeBoard.propTypes = {
   boardId: PropTypes.number.isRequired,
   title: PropTypes.string.isRequired,
-  content: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   date: PropTypes.string.isRequired,
   commentCount: PropTypes.number.isRequired,
   viewCount: PropTypes.number.isRequired,
+  content: PropTypes.string.isRequired,
+  isImagePost: PropTypes.bool,
   onClick: PropTypes.func,
 }
 

--- a/src/components/web/FreeBoard.jsx
+++ b/src/components/web/FreeBoard.jsx
@@ -44,7 +44,7 @@ const FreeBoard = ({ boardId, title, content, name, date, onClick, commentCount,
       >
         <div className='flex flex-col items-start text-left' onClick={onClick}>
           <div className='text-base font-bold truncate sm:text-lg'>{title}</div>
-          <div className='mt-2 text-sm sm:text-base line-clamp-2'>{content}</div>
+          <div className='mt-2 text-sm sm:text-base line-clamp-1'>{content}</div>
         </div>
 
         <div className='mt-4 text-xs text-dark-gray sm:text-sm'>

--- a/src/components/web/Modal.jsx
+++ b/src/components/web/Modal.jsx
@@ -17,7 +17,7 @@ const Modal = () => {
     closeModal()
   }
   return (
-    <div className='fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm'>
+    <div className='fixed inset-0 z-50 flex items-center justify-center bg-black/40'>
       <div className='relative w-[90%] max-w-md bg-white rounded-2xl p-6 shadow-xl animate-fadeIn'>
         <button
           onClick={() => {

--- a/src/domains/community/detail/components/RelatedPosts.jsx
+++ b/src/domains/community/detail/components/RelatedPosts.jsx
@@ -5,6 +5,7 @@ import MobileFreeBoard from '../../../../components/app/MobileFreeBoard'
 import Spinner from '../../../../components/web/Spinner'
 import useIsMobile from '../../../../hooks/header/useIsMobile'
 import { getAllPosts } from '../../service/postService'
+import { BsCardImage } from 'react-icons/bs'
 
 const RelatedPosts = ({ currentId }) => {
   const isMobile = useIsMobile()
@@ -43,31 +44,44 @@ const RelatedPosts = ({ currentId }) => {
               : 'grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4'
           }
         >
-          {posts.map((post) => (
-            <div key={post.boardId} className='w-full max-w-xs mx-auto'>
-              {isMobile ? (
-                <MobileFreeBoard
-                  boardId={post.boardId}
-                  title={post.title}
-                  content={post.text.replace(/<[^>]*>/g, '')}
-                  name={post.nickname}
-                  date={new Date(post.createdAt).toLocaleDateString()}
-                  commentCount={post.commentCount}
-                  viewCount={post.viewCount}
-                />
+          {posts.map((post) => {
+            const strippedText = post.text.replace(/<[^>]*>/g, '').trim()
+            const content =
+              strippedText.length === 0 ? (
+                <span className='text-gray-500 flex items-center gap-1'>
+                  <BsCardImage className='text-lg' />
+                  이미지 게시글입니다
+                </span>
               ) : (
-                <FreeBoard
-                  boardId={post.boardId}
-                  title={post.title}
-                  content={post.text.replace(/<[^>]*>/g, '')}
-                  name={post.nickname}
-                  date={new Date(post.createdAt).toLocaleDateString()}
-                  commentCount={post.commentCount}
-                  viewCount={post.viewCount}
-                />
-              )}
-            </div>
-          ))}
+                strippedText
+              )
+
+            return (
+              <div key={post.boardId} className='w-full max-w-xs mx-auto'>
+                {isMobile ? (
+                  <MobileFreeBoard
+                    boardId={post.boardId}
+                    title={post.title}
+                    content={content}
+                    name={post.nickname}
+                    date={new Date(post.createdAt).toLocaleDateString()}
+                    commentCount={post.commentCount}
+                    viewCount={post.viewCount}
+                  />
+                ) : (
+                  <FreeBoard
+                    boardId={post.boardId}
+                    title={post.title}
+                    content={content}
+                    name={post.nickname}
+                    date={new Date(post.createdAt).toLocaleDateString()}
+                    commentCount={post.commentCount}
+                    viewCount={post.viewCount}
+                  />
+                )}
+              </div>
+            )
+          })}
         </div>
       )}
     </InfiniteScrollList>

--- a/src/domains/community/detail/components/RelatedPosts.jsx
+++ b/src/domains/community/detail/components/RelatedPosts.jsx
@@ -5,8 +5,6 @@ import MobileFreeBoard from '../../../../components/app/MobileFreeBoard'
 import Spinner from '../../../../components/web/Spinner'
 import useIsMobile from '../../../../hooks/header/useIsMobile'
 import { getAllPosts } from '../../service/postService'
-import { BsCardImage } from 'react-icons/bs'
-
 const RelatedPosts = ({ currentId }) => {
   const isMobile = useIsMobile()
 
@@ -46,15 +44,8 @@ const RelatedPosts = ({ currentId }) => {
         >
           {posts.map((post) => {
             const strippedText = post.text.replace(/<[^>]*>/g, '').trim()
-            const content =
-              strippedText.length === 0 ? (
-                <span className='text-gray-500 flex items-center gap-1'>
-                  <BsCardImage className='text-lg' />
-                  이미지 게시글입니다
-                </span>
-              ) : (
-                strippedText
-              )
+            const content = strippedText.length === 0 ? '이미지 게시글입니다' : strippedText
+            const isImagePost = strippedText.length === 0
 
             return (
               <div key={post.boardId} className='w-full max-w-xs mx-auto'>
@@ -63,6 +54,7 @@ const RelatedPosts = ({ currentId }) => {
                     boardId={post.boardId}
                     title={post.title}
                     content={content}
+                    isImagePost={isImagePost}
                     name={post.nickname}
                     date={new Date(post.createdAt).toLocaleDateString()}
                     commentCount={post.commentCount}
@@ -73,6 +65,7 @@ const RelatedPosts = ({ currentId }) => {
                     boardId={post.boardId}
                     title={post.title}
                     content={content}
+                    isImagePost={isImagePost}
                     name={post.nickname}
                     date={new Date(post.createdAt).toLocaleDateString()}
                     commentCount={post.commentCount}

--- a/src/domains/community/main/page/CommunityMainPage.jsx
+++ b/src/domains/community/main/page/CommunityMainPage.jsx
@@ -10,6 +10,8 @@ import MobileFreeBoard from '../../../../components/app/MobileFreeBoard'
 import InfiniteScrollList from '../../../../components/common/InfiniteScrollList'
 import useCommunityPosts from '../hook/useCommunityPosts'
 import SeoHelmet from '../../../../components/common/SeoHelmet'
+import { BsCardImage } from 'react-icons/bs'
+
 const CommunityMainPage = () => {
   const { posts, loading, hasMore, loadMore } = useCommunityPosts()
   const [sortOrder, setSortOrder] = useState('latest')
@@ -37,10 +39,12 @@ const CommunityMainPage = () => {
           <SearchBar onSearch={handleSearch} placeholder='검색어를 입력하세요' className='w-full' />
         </div>
       </section>
+
       <div className='flex flex-col mx-4 md:mx-10 lg:mx-[100px] xl:mx-[250px]'>
         <div className='w-full flex justify-end mt-5 text-[14px] mb-3 px-4 sm:px-6 lg:px-0'>
           <PostSortDropDown onSortChange={setSortOrder} />
         </div>
+
         <div className='mt-[15px] overflow-x-auto'>
           {!posts.length && (loading || searchLoading) ? (
             <div className='flex justify-center items-center h-[300px]'>
@@ -67,34 +71,47 @@ const CommunityMainPage = () => {
                       : 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2'
                   }
                 >
-                  {displayedPosts.map((post) => (
-                    <div
-                      key={`${post.boardId}-${post.createdAt}`}
-                      className='w-full max-w-xs mx-auto'
-                    >
-                      {isMobile ? (
-                        <MobileFreeBoard
-                          boardId={post.boardId}
-                          title={post.title}
-                          content={post.text.replace(/<[^>]*>/g, '')}
-                          name={post.nickname}
-                          date={new Date(post.createdAt).toLocaleDateString()}
-                          commentCount={post.commentCount}
-                          viewCount={post.viewCount}
-                        />
+                  {displayedPosts.map((post) => {
+                    const strippedText = post.text.replace(/<[^>]*>/g, '').trim()
+                    const content =
+                      strippedText.length === 0 ? (
+                        <span className='text-gray-500 flex items-center gap-1'>
+                          <BsCardImage className='text-lg' />
+                          이미지 게시글입니다
+                        </span>
                       ) : (
-                        <FreeBoard
-                          boardId={post.boardId}
-                          title={post.title}
-                          content={post.text.replace(/<[^>]*>/g, '')}
-                          name={post.nickname}
-                          date={new Date(post.createdAt).toLocaleDateString()}
-                          commentCount={post.commentCount}
-                          viewCount={post.viewCount}
-                        />
-                      )}
-                    </div>
-                  ))}
+                        strippedText
+                      )
+
+                    return (
+                      <div
+                        key={`${post.boardId}-${post.createdAt}`}
+                        className='w-full max-w-xs mx-auto'
+                      >
+                        {isMobile ? (
+                          <MobileFreeBoard
+                            boardId={post.boardId}
+                            title={post.title}
+                            content={content}
+                            name={post.nickname}
+                            date={new Date(post.createdAt).toLocaleDateString()}
+                            commentCount={post.commentCount}
+                            viewCount={post.viewCount}
+                          />
+                        ) : (
+                          <FreeBoard
+                            boardId={post.boardId}
+                            title={post.title}
+                            content={content}
+                            name={post.nickname}
+                            date={new Date(post.createdAt).toLocaleDateString()}
+                            commentCount={post.commentCount}
+                            viewCount={post.viewCount}
+                          />
+                        )}
+                      </div>
+                    )
+                  })}
                 </div>
               </InfiniteScrollList>
 

--- a/src/domains/job/recruitment/components/form/ClosingDate.jsx
+++ b/src/domains/job/recruitment/components/form/ClosingDate.jsx
@@ -22,7 +22,12 @@ const ClosingDate = ({ control }) => {
               id='closingDate'
               type='date'
               aria-describedby='closingDateHelp'
-              className='w-full h-[58px] border border-dark-gray rounded px-4 text-black focus:border-main-pink focus:outline-none cursor-pointer  text-left'
+              className='
+              w-full h-[58px] border border-dark-gray rounded px-4 text-black 
+              focus:border-main-pink focus:outline-none cursor-pointer appearance-none
+              text-left
+            '
+              style={{ WebkitAppearance: 'none' }}
               min={minDate}
               value={dateValue}
               onChange={field.onChange}

--- a/src/domains/job/recruitment/detail/page/RecruitmentDetailPage.jsx
+++ b/src/domains/job/recruitment/detail/page/RecruitmentDetailPage.jsx
@@ -65,7 +65,7 @@ const RecruitmentDetailPage = () => {
   return (
     <div className='w-full max-w-3xl mx-auto px-4 sm:px-8 md:px-12 lg:px-20 xl:px-0'>
       <div className='flex flex-row items-center justify-between gap-2 mt-6'>
-        <span className='font-semibold text-base sm:text-xl md:text-2xl truncate max-w-[70%]'>
+        <span className='font-semibold text-[16px] sm:text-xl md:text-2xl truncate max-w-[70%]'>
           {data.nickname}
         </span>
         <button
@@ -77,16 +77,16 @@ const RecruitmentDetailPage = () => {
           <img
             src={isScrapped ? ScrapIcon : unScrapIcon}
             alt='스크랩 상태 아이콘'
-            className='w-5 h-5'
+            className='w-6 h-6'
           />
         </button>
       </div>
 
-      <div className='flex flex-col sm:flex-row justify-between items-start mt-3 gap-2'>
-        <h1 className='flex-1 min-w-0 mt-2 text-lg sm:text-2xl md:text-3xl font-bold text-left break-words'>
+      <div className='flex sm:flex-row justify-between items-start mt-3 gap-2'>
+        <h1 className='flex-1 min-w-0 text-[24px] sm:text-2xl md:text-3xl font-bold text-left break-words'>
           {data.title}
         </h1>
-        <span className='block text-dark-gray mt-2 font-bold text-xs sm:text-sm self-start shrink-0'>
+        <span className='block text-dark-gray mt-4 font-bold text-xs sm:text-sm self-start shrink-0 '>
           [구인 | 구직]
         </span>
       </div>
@@ -102,35 +102,24 @@ const RecruitmentDetailPage = () => {
       )}
       <DetailPostLine />
       <dl className='grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-5 my-5'>
-        <div className='grid grid-cols-[6rem_1fr] items-center gap-x-2'>
-          <dt className='font-semibold text-dark-gray'>근무형태</dt>
-          <dd>{getEmploymentTypeLabel(data.employmentType)}</dd>
-        </div>
-        <div className='grid grid-cols-[6rem_1fr] items-center gap-x-2'>
-          <dt className='font-semibold text-dark-gray'>경력</dt>
-          <dd>
-            {data.experienceMin}년 ~ {data.experienceMax}년
-          </dd>
-        </div>
-        <div className='grid grid-cols-[6rem_1fr] items-center gap-x-2'>
-          <dt className='font-semibold text-dark-gray'>근무지역</dt>
-          <dd>{data.location}</dd>
-        </div>
-        <div className='grid grid-cols-[6rem_1fr] items-center gap-x-2'>
-          <dt className='font-semibold text-dark-gray'>직군</dt>
-          <dd>{getJobCategoryLabel(data.jobCategory)}</dd>
-        </div>
-        <div className='grid grid-cols-[6rem_1fr] items-center gap-x-2'>
-          <dt className='font-semibold text-dark-gray'>지원 마감일</dt>
-          <dd>
-            {data.closingDate ? new Date(data.closingDate).toLocaleDateString('ko-KR') : '상시채용'}
-          </dd>
-        </div>
-        <div className='grid grid-cols-[6rem_1fr] items-center gap-x-2'>
-          <dt className='font-semibold text-dark-gray'>자사 웹사이트</dt>
-          <dd>{data.websiteUrl}</dd>
-        </div>
+        {[
+          ['근무형태', getEmploymentTypeLabel(data.employmentType)],
+          ['경력', `${data.experienceMin}년 ~ ${data.experienceMax}년`],
+          ['근무지역', data.location],
+          ['직군', getJobCategoryLabel(data.jobCategory)],
+          [
+            '지원 마감일',
+            data.closingDate ? new Date(data.closingDate).toLocaleDateString('ko-KR') : '상시채용',
+          ],
+          ['자사 웹사이트', data.websiteUrl],
+        ].map(([label, value]) => (
+          <div key={label} className='grid grid-cols-[6rem_1fr] items-start gap-x-2'>
+            <dt className='font-semibold text-dark-gray text-left text-sm sm:text-base'>{label}</dt>
+            <dd className='text-left text-sm sm:text-base break-words'>{value}</dd>
+          </div>
+        ))}
       </dl>
+
       <LastFormLine />
       <div className='flex gap-2 mb-4 ml-0 sm:ml-5 justify-end mr-0 sm:mr-3'>
         <MobileShare

--- a/src/domains/job/recruitment/detail/page/RecruitmentDetailPage.jsx
+++ b/src/domains/job/recruitment/detail/page/RecruitmentDetailPage.jsx
@@ -65,7 +65,7 @@ const RecruitmentDetailPage = () => {
   return (
     <div className='w-full max-w-3xl mx-auto px-4 sm:px-8 md:px-12 lg:px-20 xl:px-0'>
       <div className='flex flex-row items-center justify-between gap-2 mt-6'>
-        <span className='font-semibold text-[16px] sm:text-xl md:text-2xl truncate max-w-[70%]'>
+        <span className='font-semibold text-base sm:text-xl md:text-2xl truncate max-w-[70%]'>
           {data.nickname}
         </span>
         <button

--- a/src/domains/job/search/detail/page/JobSeekDetailPage.jsx
+++ b/src/domains/job/search/detail/page/JobSeekDetailPage.jsx
@@ -75,16 +75,16 @@ const JobSeekDetailPage = () => {
           <img
             src={isScrapped ? ScrapIcon : unScrapIcon}
             alt='스크랩 상태 아이콘'
-            className='w-5 h-5'
+            className='w-6 h-6'
           />
         </button>
       </div>
 
-      <div className='flex flex-col sm:flex-row justify-between items-start mt-3 gap-2'>
-        <h1 className='flex-1 min-w-0 mt-2 text-lg sm:text-2xl md:text-3xl font-bold text-left break-words'>
+      <div className='flex sm:flex-row justify-between items-start mt-3 gap-2'>
+        <h1 className='flex-1 min-w-0 text-[24px] sm:text-2xl md:text-3xl font-bold text-left break-words mt-2'>
           {data.title}
         </h1>
-        <span className='block text-dark-gray mt-2 font-bold text-xs sm:text-sm self-start shrink-0'>
+        <span className='block text-dark-gray mt-4 font-bold text-xs sm:text-sm self-start shrink-0 '>
           [구인 | 구직]
         </span>
       </div>

--- a/src/utils/toastService.js
+++ b/src/utils/toastService.js
@@ -2,9 +2,9 @@ import { toast } from 'react-toastify'
 import 'react-toastify/dist/ReactToastify.css'
 
 const defaultOptions = {
-  position: 'top-center',
+  position: 'bottom-center',
   autoClose: 2000,
-  hideProgressBar: false,
+  hideProgressBar: true,
   closeOnClick: true,
   pauseOnHover: true,
   draggable: true,
@@ -15,6 +15,9 @@ const baseStyle = {
   boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
   fontWeight: '600',
   transition: 'transform 0.3s ease, opacity 0.3s ease',
+  margin: '0 auto',
+  borderRadius: '36px',
+  padding: '12px 16px',
 }
 
 const ToastService = {


### PR DESCRIPTION
## #️⃣연관된 이슈

#187 

### 📝작업 내용

- [x] toastify 반응형으로 수정
- [x] 구인 상세 페이지 category 일렬로 정렬
- [x] 모바일 기준  구인 폼에 구인 마감  inpuxbox 수정
- [x] 모바일 기준 모달창 z-index가 가장 높게 수정 
- [x] 이미지만 있는 게시글인 경우 따로 처리해주기

### 📸 스크린샷 (선택)
**toastify 반응형으로 수정**

<img width="1416" alt="스크린샷 2025-06-24 오후 3 45 59" src="https://github.com/user-attachments/assets/8317d1e3-9238-41b9-99ee-a8f8139a1782" />

<img width="307" alt="스크린샷 2025-06-24 오후 345 43" src="https://github.com/user-attachments/assets/97cd6f19-1e1f-4a0e-87ae-73ff1d5032b3" />


-----
**구인 상세 페이지 category 일렬로 정렬**
<img width="1440" alt="스크린샷 2025-06-24 오후 3 44 17" src="https://github.com/user-attachments/assets/c8a9c464-b717-42bf-afde-e0713b778af1" />

<img width="250" alt="스크린샷 2025-06-24 오후 3 44 29" src="https://github.com/user-attachments/assets/6351b410-0810-472b-bd41-cb22c7202ac2" />


----
**이미지만 있는 게시글인 경우 따로 처리해주기**

<img width="1440" alt="스크린샷 2025-06-24 오후 3 43 51" src="https://github.com/user-attachments/assets/ab4adf17-dca6-4efa-a1af-6d15f5725f27" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
    - 이미지로만 구성된 게시글에 "이미지 게시글입니다" 메시지와 이미지 아이콘이 표시됩니다.

- **스타일**
    - 토스트 알림 위치가 상단 중앙에서 하단 중앙으로 변경되고, 진행 바가 숨겨집니다. 토스트 알림의 모서리가 더 둥글고, 여백 및 패딩이 추가되어 시각적으로 개선되었습니다.
    - FreeBoard에서 게시글 미리보기가 2줄에서 1줄로 축소되어 더 간결하게 표시됩니다.
    - 모달 배경의 블러 효과가 제거되어 더 깔끔한 배경이 적용됩니다.
    - 구인/구직 상세 페이지의 스크랩 아이콘 크기가 커지고, 제목 및 라벨의 정렬과 여백이 개선되었습니다.

- **리팩터**
    - 구인/구직 상세 정보 섹션이 일관된 스타일과 구조로 리팩터링되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->