### PR TITLE
[feature-36/feat]내가 작성한 글 무한스크롤 / 최근본 목록 추가/ 비밀번호 변경 페이지 반응형 변경 

### DIFF
--- a/src/components/web/BoardCategory.jsx
+++ b/src/components/web/BoardCategory.jsx
@@ -1,16 +1,14 @@
 import PropTypes from 'prop-types'
 
-const BoardCategory = ({ label, bgColor = '#ECFDF5', labelColor = '#1B7500', width = '81px' }) => {
+const BoardCategory = ({ label = '자유게시판' }) => {
+  const boardLabel = {
+    자유게시판: 'bg-[#ECFDF5] text-[#1B7500] w-[81px]',
+    구인: 'bg-[#EBF7FF] text-[#2563EB] w-[60px]',
+    구직: 'bg-[#FFEFEB] text-[#DC2626] w-[60px]',
+    기타: 'bg-[#cecece] text-[#2e2e2e] w-[60px]',
+  }
   return (
-    <button
-      className='h-[24px] text-[14px] font-semibold'
-      style={{
-        backgroundColor: bgColor,
-        color: labelColor,
-        width,
-        borderRadius: '6px',
-      }}
-    >
+    <button className={`h-[24px] text-[14px] font-semibold rounded-md ${boardLabel[label]}`}>
       {label}
     </button>
   )

--- a/src/components/web/BoardCategory.jsx
+++ b/src/components/web/BoardCategory.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 
-const BoardCategory = ({ label = '자유게시판' }) => {
+const BoardCategory = ({ label = '기타' }) => {
   const boardLabel = {
     자유게시판: 'bg-[#ECFDF5] text-[#1B7500] w-[81px]',
     구인: 'bg-[#EBF7FF] text-[#2563EB] w-[60px]',

--- a/src/components/web/FreeBoard.jsx
+++ b/src/components/web/FreeBoard.jsx
@@ -36,7 +36,7 @@ const FreeBoard = ({
 
   return (
     <div
-      className='w-full max-w-md sm:max-w-[350px] md:max-w-[400px] mx-auto'
+      className='w-full max-w-md sm:max-w-[350px] md:max-w-[400px] mx-auto '
       onClick={goToDetailPage}
     >
       <div

--- a/src/components/web/WorkBoard.jsx
+++ b/src/components/web/WorkBoard.jsx
@@ -96,11 +96,11 @@ const WorkBoard = ({
           </div>
           <h3
             onClick={onClick}
-            className='flex font-bold line-clamp-2 text-sm sm:text-base md:text-lg mb-1'
+            className='flex mb-1 text-sm font-bold line-clamp-2 sm:text-base md:text-lg'
           >
             {title}
           </h3>
-          <div className='flex-row text-dark-gray text-xs sm:text-sm md:text-base'>
+          <div className='flex-row text-xs text-dark-gray sm:text-sm md:text-base'>
             <div onClick={onClick} className='flex justify-end font-bold'>
               {name}
             </div>

--- a/src/domains/Find/common/components/NewPasswordInput.jsx
+++ b/src/domains/Find/common/components/NewPasswordInput.jsx
@@ -7,7 +7,7 @@ const NewPasswordInput = ({ register, errors, watch }) => {
       <div className='flex flex-col w-full gap-3'>
         <div>
           <PwInputBox
-            placeholder='비밀번호는 영문 숫자 포함 최소 8자 이상을 입력해주세요'
+            placeholder='영문 숫자 포함 최소 8자 이상을 입력해주세요'
             size='biggest'
             {...register('newPassword', {
               required: '새로 사용할 비밀번호를 입력하세요',

--- a/src/domains/Find/detail/ChangePwPage.jsx
+++ b/src/domains/Find/detail/ChangePwPage.jsx
@@ -9,12 +9,14 @@ import ROUTER_PATHS from '../../../routes/RouterPath'
 import useAuthStore from '../../../store/login/useAuthStore'
 import { postNewPW } from '../../my/services/userMyDataServices'
 import ToastService from '../../../utils/toastService'
+import useIsMobile from '../../../hooks/header/useIsMobile'
 
 const ChangePwPage = () => {
   const navigate = useNavigate()
   const [isSuccess, setIsSuccess] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   const { resetToken, requireResetToken, clearResetToken } = useAuthStore()
+  const isMobile = useIsMobile()
   const {
     register,
     handleSubmit,
@@ -68,26 +70,28 @@ const ChangePwPage = () => {
       setIsLoading(false)
     }
   }
-
+  const formContent = (
+    <>
+      <form onSubmit={handleSubmit(onSubmit)} className='w-full'>
+        <div className='flex justify-start text-3xl font-bold mb-9'>비밀번호 변경</div>
+        <NewPasswordInput register={register} errors={errors} watch={watch} />
+        <div className='mt-8'>
+          <Button
+            label='완료'
+            size='biggest'
+            bgColor={isSuccess && !isLoading ? 'main-pink' : 'light-gray'}
+            disabled={!isSuccess || isLoading}
+            type='submit'
+          />
+        </div>
+      </form>
+    </>
+  )
   return (
     <div>
-      <PageTitle title={'비밀번호 변경'} />
+      {isMobile ? null : <PageTitle title={'비밀번호 변경'} />}
       <div className='flex justify-center w-full'>
-        <PageBox>
-          <div className='flex justify-start text-3xl font-bold mb-9'>비밀번호 변경</div>
-          <form onSubmit={handleSubmit(onSubmit)}>
-            <NewPasswordInput register={register} errors={errors} watch={watch} />
-            <div className='mt-8'>
-              <Button
-                label='완료'
-                size='biggest'
-                bgColor={isSuccess && !isLoading ? 'main-pink' : 'light-gray'}
-                disabled={!isSuccess || isLoading}
-                type='submit'
-              />
-            </div>
-          </form>
-        </PageBox>
+        {isMobile ? formContent : <PageBox>{formContent}</PageBox>}
       </div>
     </div>
   )

--- a/src/domains/community/detail/page/DetailCommunityPage.jsx
+++ b/src/domains/community/detail/page/DetailCommunityPage.jsx
@@ -1,6 +1,6 @@
 import { useParams, useNavigate } from 'react-router-dom'
 import ROUTER_PATHS from '../../../../routes/RouterPath'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import useDetailPost from '../hook/useDetailPost'
 import Spinner from '../../../../components/web/Spinner'
 import MobileShare from '../../../../components/app/MobileShare'
@@ -18,6 +18,7 @@ import ToastService from '../../../../utils/toastService'
 import WriteEditor from '../../../../components/common/editor/WriteEditor'
 import useEditPost from '../hook/useEditPost'
 import DOMPurify from 'dompurify'
+import { saveTOStorage } from '../../../my/detail/components/saveToStorage'
 
 const DetailCommunityPage = () => {
   const { id } = useParams()
@@ -28,6 +29,7 @@ const DetailCommunityPage = () => {
   const comments = useCommentStore((state) => state.comments)
   const fetchComments = useCommentStore((state) => state.fetchComments)
   const currentUrl = window.location.href
+  const hasSaved = useRef(false)
 
   const {
     content,
@@ -42,6 +44,14 @@ const DetailCommunityPage = () => {
       fetchComments(id)
     }
   }, [id])
+
+  useEffect(() => {
+    if (post && !hasSaved.current) {
+      saveTOStorage(post, id, 'community');
+      hasSaved.current = true
+    }
+  }, [post, id])
+
 
   if (loading) {
     return (
@@ -73,8 +83,8 @@ const DetailCommunityPage = () => {
     ToastService.warn('이 사용자를 차단합니다.')
   }
 
-  if (error) return <div className='text-center text-red-500 mt-10'>오류가 발생했어요.</div>
-  if (!post) return <div className='text-center text-gray-500 mt-10'>게시글이 존재하지 않아요.</div>
+  if (error) return <div className='mt-10 text-center text-red-500'>오류가 발생했어요.</div>
+  if (!post) return <div className='mt-10 text-center text-gray-500'>게시글이 존재하지 않아요.</div>
 
   return (
     <div className='w-full max-w-[1440px] mx-auto px-4 sm:px-8 lg:px-[100px] xl:px-[250px] py-6 sm:py-10'>
@@ -86,7 +96,7 @@ const DetailCommunityPage = () => {
       </div>
 
       {post?.isWriter ? (
-        <div className='flex gap-4 mt-4 mb-2 justify-end'>
+        <div className='flex justify-end gap-4 mt-4 mb-2'>
           {!isEditing ? (
             <>
               <button className='text-dark-gray text-[13px]' onClick={handleEditClick}>
@@ -116,7 +126,7 @@ const DetailCommunityPage = () => {
           )}
         </div>
       ) : (
-        <div className='flex gap-4 mt-4 mb-2 justify-end'>
+        <div className='flex justify-end gap-4 mt-4 mb-2'>
           <button className='text-dark-gray text-[13px]' onClick={handleBlockUserClick}>
             차단
           </button>
@@ -125,7 +135,7 @@ const DetailCommunityPage = () => {
 
       <LastFormLine />
 
-      <div className='flex flex-wrap gap-2 mb-4 ml-0 sm:ml-5 justify-end'>
+      <div className='flex flex-wrap justify-end gap-2 mb-4 ml-0 sm:ml-5'>
         <MobileShare label={post.viewCount.toString()} icon={viewPink} textColor='text-main-pink' />
         <MobileShare label={comments.length.toString()} icon={comment} textColor='text-dark-gray' />
         <MobileShare
@@ -147,7 +157,7 @@ const DetailCommunityPage = () => {
           />
         ) : (
           <div
-            className='whitespace-pre-line break-words text-left'
+            className='text-left break-words whitespace-pre-line'
             dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(post.text) }}
           />
         )}
@@ -164,7 +174,7 @@ const DetailCommunityPage = () => {
         <CommentForm boardId={id} onCommentAdded={() => fetchComments(id)} />
         {isCommentOpen && <CommentList boardId={id} />}
         <LastFormLine />
-        <h2 className='font-bold text-lg sm:text-xl my-5 flex self-start'>관련 글</h2>
+        <h2 className='flex self-start my-5 text-lg font-bold sm:text-xl'>관련 글</h2>
         <RelatedPosts currentId={id} />
       </div>
     </div>

--- a/src/domains/job/main/page/JobMainPage.jsx
+++ b/src/domains/job/main/page/JobMainPage.jsx
@@ -80,7 +80,7 @@ const JobMainPage = () => {
 
   return (
     <>
-      <section className='w-full flex justify-center mt-7 px-7'>
+      <section className='flex justify-center w-full mt-7 px-7'>
         <SeoHelmet
           title='북잡 | 출판업계 구인 & 구직'
           description='출판 업계의 구인 | 구직 공고를 한눈에 확인해보세요. 실시간으로 업데이트됩니다.'
@@ -99,7 +99,7 @@ const JobMainPage = () => {
         </div>
       </section>
       <div className='flex flex-col mx-4 md:mx-10 lg:mx-[100px] xl:mx-[250px]'>
-        <div className='flex items-end ml-auto px-5 sm:px-0'>
+        <div className='flex items-end px-5 ml-auto sm:px-0'>
           <JobDropDown selectedJobTabs={selectedTab} handleTabChange={setSelectedTab} />
           <JobPostSortDropDown onSortChange={setOrder} options={sortOptions} selected={order} />
         </div>

--- a/src/domains/job/recruitment/detail/page/RecruitmentDetailPage.jsx
+++ b/src/domains/job/recruitment/detail/page/RecruitmentDetailPage.jsx
@@ -26,6 +26,7 @@ const RecruitmentDetailPage = () => {
   const isScrapped = Boolean(scraps[id])
   const currentUrl = window.location.href
   const navigate = useNavigate()
+  console.log('목록 data', data)
 
   if (loading) {
     return (
@@ -63,7 +64,7 @@ const RecruitmentDetailPage = () => {
   }
 
   return (
-    <div className='w-full max-w-3xl mx-auto px-4 sm:px-8 md:px-12 lg:px-20 xl:px-0'>
+    <div className='w-full max-w-3xl px-4 mx-auto sm:px-8 md:px-12 lg:px-20 xl:px-0'>
       <div className='flex flex-row items-center justify-between gap-2 mt-6'>
         <span className='font-semibold text-base sm:text-xl md:text-2xl truncate max-w-[70%]'>
           {data.nickname}
@@ -82,16 +83,16 @@ const RecruitmentDetailPage = () => {
         </button>
       </div>
 
-      <div className='flex sm:flex-row justify-between items-start mt-3 gap-2'>
+      <div className='flex items-start justify-between gap-2 mt-3 sm:flex-row'>
         <h1 className='flex-1 min-w-0 text-[24px] sm:text-2xl md:text-3xl font-bold text-left break-words'>
           {data.title}
         </h1>
-        <span className='block text-dark-gray mt-4 font-bold text-xs sm:text-sm self-start shrink-0 '>
+        <span className='self-start block mt-4 text-xs font-bold text-dark-gray sm:text-sm shrink-0 '>
           [구인 | 구직]
         </span>
       </div>
       {user && user.nickname === data.nickname && (
-        <div className='flex justify-end mt-5 gap-4 text-sm text-dark-gray'>
+        <div className='flex justify-end gap-4 mt-5 text-sm text-dark-gray'>
           <span className='cursor-pointer' onClick={handleEditClick}>
             수정
           </span>
@@ -101,7 +102,7 @@ const RecruitmentDetailPage = () => {
         </div>
       )}
       <DetailPostLine />
-      <dl className='grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-5 my-5'>
+      <dl className='grid grid-cols-1 my-5 sm:grid-cols-2 gap-x-8 gap-y-5'>
         {[
           ['근무형태', getEmploymentTypeLabel(data.employmentType)],
           ['경력', `${data.experienceMin}년 ~ ${data.experienceMax}년`],
@@ -114,14 +115,14 @@ const RecruitmentDetailPage = () => {
           ['자사 웹사이트', data.websiteUrl],
         ].map(([label, value]) => (
           <div key={label} className='grid grid-cols-[6rem_1fr] items-start gap-x-2'>
-            <dt className='font-semibold text-dark-gray text-left text-sm sm:text-base'>{label}</dt>
-            <dd className='text-left text-sm sm:text-base break-words'>{value}</dd>
+            <dt className='text-sm font-semibold text-left text-dark-gray sm:text-base'>{label}</dt>
+            <dd className='text-sm text-left break-words sm:text-base'>{value}</dd>
           </div>
         ))}
       </dl>
 
       <LastFormLine />
-      <div className='flex gap-2 mb-4 ml-0 sm:ml-5 justify-end mr-0 sm:mr-3'>
+      <div className='flex justify-end gap-2 mb-4 ml-0 mr-0 sm:ml-5 sm:mr-3'>
         <MobileShare
           label='공유'
           icon={share}
@@ -134,11 +135,11 @@ const RecruitmentDetailPage = () => {
         <MobileShare label={data.viewCount} icon={viewPink} textColor='text-main-pink' />
       </div>
       <div
-        className='block mt-4 mb-10 whitespace-pre-line text-sm sm:text-base break-words text-left'
+        className='block mt-4 mb-10 text-sm text-left break-words whitespace-pre-line sm:text-base'
         dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(data.text) }}
       />
       <LastFormLine />
-      <h2 className='font-bold text-lg sm:text-xl my-5 flex self-start'>관련 글</h2>
+      <h2 className='flex self-start my-5 text-lg font-bold sm:text-xl'>관련 글</h2>
       <RelatedRecruitmentPosts currentId={id} />
     </div>
   )

--- a/src/domains/job/recruitment/detail/page/RecruitmentDetailPage.jsx
+++ b/src/domains/job/recruitment/detail/page/RecruitmentDetailPage.jsx
@@ -17,6 +17,8 @@ import useAuthStore from '../../../../../store/login/useAuthStore'
 import useScrapStore from '../../../scrap/store/useScrapStore'
 import ToastService from '../../../../../utils/toastService'
 import DOMPurify from 'dompurify'
+import { useEffect, useRef } from 'react'
+import { saveTOStorage } from '../../../../my/detail/components/saveToStorage'
 
 const RecruitmentDetailPage = () => {
   const { user } = useAuthStore()
@@ -25,8 +27,15 @@ const RecruitmentDetailPage = () => {
   const { scraps, toggleScrap, loading: scrapLoading } = useScrapStore()
   const isScrapped = Boolean(scraps[id])
   const currentUrl = window.location.href
+  const hasSaved = useRef(false)
+
   const navigate = useNavigate()
-  console.log('목록 data', data)
+  useEffect(() => {
+    if (data && !hasSaved.current) {
+      saveTOStorage(data, id, 'jobPostings');
+      hasSaved.current = true
+    }
+  }, [data, id])
 
   if (loading) {
     return (
@@ -62,7 +71,7 @@ const RecruitmentDetailPage = () => {
       console.error('오류')
     }
   }
-
+  
   return (
     <div className='w-full max-w-3xl px-4 mx-auto sm:px-8 md:px-12 lg:px-20 xl:px-0'>
       <div className='flex flex-row items-center justify-between gap-2 mt-6'>

--- a/src/domains/job/search/detail/page/JobSeekDetailPage.jsx
+++ b/src/domains/job/search/detail/page/JobSeekDetailPage.jsx
@@ -17,6 +17,8 @@ import RelatedJobSearchPosts from '../components/RelatedJobSearchPosts'
 import useScrapStore from '../../../scrap/store/useScrapStore'
 import ToastService from '../../../../../utils/toastService'
 import DOMPurify from 'dompurify'
+import { useEffect, useRef } from 'react'
+import { saveTOStorage } from '../../../../my/detail/components/saveToStorage'
 
 const JobSeekDetailPage = () => {
   const { user } = useAuthStore()
@@ -26,6 +28,14 @@ const JobSeekDetailPage = () => {
   const isScrapped = Boolean(scraps[id])
   const currentUrl = window.location.href
   const navigate = useNavigate()
+  const hasSaved = useRef(false)
+
+  useEffect(() => {
+    if (data && !hasSaved.current) {
+      saveTOStorage(data, id, 'jobSeekings');
+      hasSaved.current = true
+    }
+  }, [data, id])
 
   if (loading) {
     return (
@@ -61,7 +71,7 @@ const JobSeekDetailPage = () => {
   }
 
   return (
-    <div className='w-full max-w-3xl mx-auto px-4 sm:px-8 md:px-12 lg:px-20 xl:px-0'>
+    <div className='w-full max-w-3xl px-4 mx-auto sm:px-8 md:px-12 lg:px-20 xl:px-0'>
       <div className='flex flex-row items-center justify-between gap-2 mt-6'>
         <span className='font-semibold text-base sm:text-xl md:text-2xl truncate max-w-[70%]'>
           {data.nickname}
@@ -80,17 +90,17 @@ const JobSeekDetailPage = () => {
         </button>
       </div>
 
-      <div className='flex sm:flex-row justify-between items-start mt-3 gap-2'>
+      <div className='flex items-start justify-between gap-2 mt-3 sm:flex-row'>
         <h1 className='flex-1 min-w-0 text-[24px] sm:text-2xl md:text-3xl font-bold text-left break-words mt-2'>
           {data.title}
         </h1>
-        <span className='block text-dark-gray mt-4 font-bold text-xs sm:text-sm self-start shrink-0 '>
+        <span className='self-start block mt-4 text-xs font-bold text-dark-gray sm:text-sm shrink-0 '>
           [구인 | 구직]
         </span>
       </div>
 
       {user && user.nickname === data.nickname && (
-        <div className='flex justify-end mt-5 gap-4 text-sm text-dark-gray'>
+        <div className='flex justify-end gap-4 mt-5 text-sm text-dark-gray'>
           <p className='cursor-pointer' onClick={handleEditClick}>
             수정
           </p>
@@ -100,7 +110,7 @@ const JobSeekDetailPage = () => {
         </div>
       )}
       <DetailPostLine />
-      <dl className='grid gap-y-4 my-5'>
+      <dl className='grid my-5 gap-y-4'>
         {[
           ['근무형태', getEmploymentTypeLabel(data.employmentType)],
           ['직군', getJobCategoryLabel(data.jobCategory)],
@@ -111,13 +121,13 @@ const JobSeekDetailPage = () => {
             key={label}
             className='grid grid-cols-1 sm:grid-cols-[10rem_1fr] gap-x-4 items-start'
           >
-            <dt className='font-semibold text-dark-gray text-left text-sm sm:text-base'>{label}</dt>
-            <dd className='text-left text-sm sm:text-base break-words'>{value}</dd>
+            <dt className='text-sm font-semibold text-left text-dark-gray sm:text-base'>{label}</dt>
+            <dd className='text-sm text-left break-words sm:text-base'>{value}</dd>
           </div>
         ))}
       </dl>
       <LastFormLine />
-      <div className='flex gap-2 mb-4 ml-0 sm:ml-5 justify-end mr-0 sm:mr-3'>
+      <div className='flex justify-end gap-2 mb-4 ml-0 mr-0 sm:ml-5 sm:mr-3'>
         <MobileShare
           label='공유'
           icon={share}
@@ -130,11 +140,11 @@ const JobSeekDetailPage = () => {
         <MobileShare label={data.viewCount} icon={viewPink} textColor='text-main-pink' />
       </div>
       <div
-        className='block mt-4 mb-10 whitespace-pre-line text-sm sm:text-base break-words text-left'
+        className='block mt-4 mb-10 text-sm text-left break-words whitespace-pre-line sm:text-base'
         dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(data.text) }}
       />
       <LastFormLine />
-      <h2 className='font-bold text-lg sm:text-xl mt-7 flex self-start'>관련 글</h2>
+      <h2 className='flex self-start text-lg font-bold sm:text-xl mt-7'>관련 글</h2>
       <RelatedJobSearchPosts currentId={id} />
     </div>
   )

--- a/src/domains/my/detail/MyDrafts.jsx
+++ b/src/domains/my/detail/MyDrafts.jsx
@@ -1,10 +1,9 @@
 import { useNavigate } from 'react-router-dom'
 import PageTitle from '../../Find/common/components/PageTitle'
 import MyDraftsList from './components/MyDraftsList'
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import ROUTER_PATHS from '../../../routes/RouterPath'
 import useIsMobile from '../../../hooks/header/useIsMobile'
-import ToastService from '../../../utils/toastService'
 import useFreeDraftStore from './../../../store/mypage/useFreeDraftStore'
 
 const MyDrafts = () => {

--- a/src/domains/my/detail/MyPost.jsx
+++ b/src/domains/my/detail/MyPost.jsx
@@ -9,7 +9,7 @@ import { useEffect } from 'react'
 
 const MyPost = () => {
   const { choiceBoard } = useBoardStore()
-  const { fetchFreeBoard, fetchJobBoard, resetBoard } = useMyBoardStore()
+  const { fetchFreeBoard, fetchJobBoard, resetBoard, freeError, jobError } = useMyBoardStore()
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useInfiniteQuery({
     queryKey: ['myPosts', choiceBoard],
@@ -17,14 +17,11 @@ const MyPost = () => {
       const response = await (choiceBoard === '자유게시판'
         ? fetchFreeBoard(pageParam, 10)
         : fetchJobBoard(pageParam, 10))
-      console.log('API Response:', response)
       return response
     },
     getNextPageParam: (lastPage) => {
-      console.log('Last Page:', lastPage)
       return lastPage.data.hasNext ? lastPage.data.currentPage + 1 : undefined
     },
-    onError: (err) => console.error('Query Error:', err),
   })
 
   const posts =
@@ -33,7 +30,6 @@ const MyPost = () => {
         ? page.data.myPostingsInBoardList || []
         : page.data.postings || [],
     ) || []
-  console.log('Posts:', posts, 'isLoading:', isLoading)
 
   useEffect(() => {
     resetBoard(choiceBoard === '자유게시판' ? 'free' : 'job')
@@ -49,9 +45,9 @@ const MyPost = () => {
           </div>
         ) : posts.length === 0 ? (
           <p className='text-dark-gray'>작성 글이 없습니다.</p>
-        ) : useMyBoardStore.getState()[choiceBoard === '자유게시판' ? 'freeError' : 'jobError'] ? (
+        ) : (choiceBoard === '자유게시판' ? freeError : jobError) ? (
           <div className='flex flex-col text-center text-red-500'>
-            {useMyBoardStore.getState()[choiceBoard === '자유게시판' ? 'freeError' : 'jobError']}
+            {choiceBoard === '자유게시판' ? freeError : jobError}
             <button
               onClick={() =>
                 choiceBoard === '자유게시판' ? fetchFreeBoard(0, 10) : fetchJobBoard(0, 10)
@@ -69,7 +65,7 @@ const MyPost = () => {
             <PostList boardData={posts} />
             {isFetchingNextPage && (
               <div className='flex justify-center items-center h-[100px]'>
-              <Spinner size={38} color='main-pink' />
+                <Spinner size={38} color='main-pink' />
               </div>
             )}
             {!hasNextPage && posts.length > 0 && (

--- a/src/domains/my/detail/MyPost.jsx
+++ b/src/domains/my/detail/MyPost.jsx
@@ -1,42 +1,60 @@
+import { useInfiniteQuery } from '@tanstack/react-query'
 import MyPostHead from './components/MyPostHead'
 import PostList from './components/PostList'
 import useBoardStore from '../../../store/mypage/useBoardStore'
 import useMyBoardStore from '../../../store/mypage/useMyBoardStore'
-import { useEffect } from 'react'
 import Spinner from '../../../components/web/Spinner'
+import InfiniteScrollList from '../../../components/common/InfiniteScrollList'
+import { useEffect } from 'react'
 
 const MyPost = () => {
   const { choiceBoard } = useBoardStore()
+  const { fetchFreeBoard, fetchJobBoard, resetBoard } = useMyBoardStore()
 
-  const { isFreeLoading, isJobLoading, freeError, jobError, fetchFreeBoard, fetchJobBoard } =
-    useMyBoardStore()
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useInfiniteQuery({
+    queryKey: ['myPosts', choiceBoard],
+    queryFn: async ({ pageParam = 0 }) => {
+      const response = await (choiceBoard === '자유게시판'
+        ? fetchFreeBoard(pageParam, 10)
+        : fetchJobBoard(pageParam, 10))
+      console.log('API Response:', response)
+      return response
+    },
+    getNextPageParam: (lastPage) => {
+      console.log('Last Page:', lastPage)
+      return lastPage.data.hasNext ? lastPage.data.currentPage + 1 : undefined
+    },
+    onError: (err) => console.error('Query Error:', err),
+  })
+
+  const posts =
+    data?.pages.flatMap((page) =>
+      choiceBoard === '자유게시판'
+        ? page.data.myPostingsInBoardList || []
+        : page.data.postings || [],
+    ) || []
+  console.log('Posts:', posts, 'isLoading:', isLoading)
 
   useEffect(() => {
-    const token = localStorage.getItem('Authorization')
-    if (token) {
-      fetchFreeBoard(token, true)
-      fetchJobBoard(token, true)
-    }
-  }, [fetchFreeBoard, fetchJobBoard])
+    resetBoard(choiceBoard === '자유게시판' ? 'free' : 'job')
+  }, [choiceBoard, resetBoard])
 
-  const isLoading = choiceBoard === '자유게시판' ? isFreeLoading : isJobLoading
-  const error = choiceBoard === '자유게시판' ? freeError : jobError
   return (
     <div className='w-full'>
-      <div className=' sm:max-w-[940px] mx-auto px-4'>
+      <div className='sm:max-w-[940px] mx-auto px-4'>
         <MyPostHead choiceBoard={choiceBoard} />
-        {isLoading ? (
-          <div className='text-center'>
+        {isLoading && posts.length === 0 ? (
+          <div className='flex justify-center items-center h-[100px]'>
             <Spinner size={48} color='main-pink' />
           </div>
-        ) : error ? (
+        ) : posts.length === 0 ? (
+          <p className='text-dark-gray'>작성 글이 없습니다.</p>
+        ) : useMyBoardStore.getState()[choiceBoard === '자유게시판' ? 'freeError' : 'jobError'] ? (
           <div className='flex flex-col text-center text-red-500'>
-            {error}
+            {useMyBoardStore.getState()[choiceBoard === '자유게시판' ? 'freeError' : 'jobError']}
             <button
               onClick={() =>
-                choiceBoard === '자유게시판'
-                  ? fetchFreeBoard(localStorage.getItem('Authorization'), true)
-                  : fetchJobBoard(localStorage.getItem('Authorization'), true)
+                choiceBoard === '자유게시판' ? fetchFreeBoard(0, 10) : fetchJobBoard(0, 10)
               }
               className='ml-2 text-blue-500'
             >
@@ -44,7 +62,22 @@ const MyPost = () => {
             </button>
           </div>
         ) : (
-          <PostList />
+          <InfiniteScrollList
+            onIntersect={() => fetchNextPage()}
+            disabled={!hasNextPage || isFetchingNextPage}
+          >
+            <PostList boardData={posts} />
+            {isFetchingNextPage && (
+              <div className='flex justify-center items-center h-[100px]'>
+              <Spinner size={38} color='main-pink' />
+              </div>
+            )}
+            {!hasNextPage && posts.length > 0 && (
+              <div className='flex items-center justify-center py-8 text-sm text-dark-gray'>
+                더 이상 불러올 작성글이 없습니다.
+              </div>
+            )}
+          </InfiniteScrollList>
         )}
       </div>
     </div>

--- a/src/domains/my/detail/MyRecentList.jsx
+++ b/src/domains/my/detail/MyRecentList.jsx
@@ -9,7 +9,13 @@ const MyRecentList = () => {
   const [sort, setSort] = useState('latest')
 
   const sortedPosts = useMemo(() => {
-    const recentList = JSON.parse(sessionStorage.getItem('RecentListSave')) || []
+    let recentList = []
+    try {
+      recentList = JSON.parse(sessionStorage.getItem('RecentListSave')) || []
+    } catch (error) {
+      console.warn('최근 본 목록 데이터를 불러오는데 실패했습니다:', error)
+      sessionStorage.removeItem('RecentListSave')
+    }
     return recentList.sort((a, b) => {
       return sort === 'latest'
         ? new Date(b.date) - new Date(a.date)

--- a/src/domains/my/detail/MyRecentList.jsx
+++ b/src/domains/my/detail/MyRecentList.jsx
@@ -1,15 +1,37 @@
-import { useNavigate } from 'react-router-dom'
 import useIsMobile from '../../../hooks/header/useIsMobile'
 import PageTitle from '../../Find/common/components/PageTitle'
+import { useMemo, useState } from 'react'
+import PostSortDropDown from '../../../components/common/PostSortDropDown'
+import RecentList from './components/RecentList'
 
 const MyRecentList = () => {
-  const navigate = useNavigate()
   const isMobile = useIsMobile()
+  const [sort, setSort] = useState('latest')
+
+  const sortedPosts = useMemo(() => {
+    const recentList = JSON.parse(sessionStorage.getItem('RecentListSave')) || []
+    return recentList.sort((a, b) => {
+      return sort === 'latest'
+        ? new Date(b.date) - new Date(a.date)
+        : new Date(a.date) - new Date(b.date)
+    })
+  }, [sort])
+
   return (
     <div>
       <div className='sm:mt-10'>{isMobile ? null : <PageTitle title={'최근본 목록'} />}</div>
-      최근본 목록
-      
+      {sortedPosts.length === 0 && (
+        <div className='items-center text-center text-dark-gray'>최근 본 글이 없습니다.</div>
+      )}
+      {sortedPosts.length > 0 && (
+        <>
+          <div className='flex justify-end max-w-[932px] pr-4 mx-auto mb-2'>
+            <PostSortDropDown onSortChange={setSort} />
+          </div>
+          <RecentList sortedPosts={sortedPosts} />
+          <p className='my-10 text-center text-dark-gray'>최근본 목록은 최대 30개까지 입니다.</p>
+        </>
+      )}
     </div>
   )
 }

--- a/src/domains/my/detail/MyRecentList.jsx
+++ b/src/domains/my/detail/MyRecentList.jsx
@@ -1,0 +1,17 @@
+import { useNavigate } from 'react-router-dom'
+import useIsMobile from '../../../hooks/header/useIsMobile'
+import PageTitle from '../../Find/common/components/PageTitle'
+
+const MyRecentList = () => {
+  const navigate = useNavigate()
+  const isMobile = useIsMobile()
+  return (
+    <div>
+      <div className='sm:mt-10'>{isMobile ? null : <PageTitle title={'최근본 목록'} />}</div>
+      최근본 목록
+      
+    </div>
+  )
+}
+
+export default MyRecentList

--- a/src/domains/my/detail/components/MyDraftsList.jsx
+++ b/src/domains/my/detail/components/MyDraftsList.jsx
@@ -30,14 +30,12 @@ const MyDraftsList = ({ draftsListData, onDraftClick }) => {
     }
   }
   const sortedDrafts = useMemo(() => {
-    console.log('draftsListData', draftsListData)
-
     return draftsListData.sort((a, b) => {
       return sort === 'latest'
         ? new Date(b.date) - new Date(a.date)
         : new Date(a.date) - new Date(b.date)
     })
-  }, [sort])
+  }, [draftsListData, sort])
   return (
     <div className='w-full sm:max-w-[940px] mx-auto px-4 sm:px-10'>
       {sortedDrafts.length > 0 && (
@@ -45,10 +43,10 @@ const MyDraftsList = ({ draftsListData, onDraftClick }) => {
           <PostSortDropDown onSortChange={setSort} />
         </div>
       )}
-      {draftsListData.length === 0 ? (
+      {sortedDrafts.length === 0 ? (
         <p className='text-center text-dark-gray'>임시 저장된 글이 없습니다.</p>
       ) : (
-        draftsListData.map((item) => {
+        sortedDrafts.map((item) => {
           const previewText = getPreviewText(item.text)
           const hasImage = item.text && item.text.includes('<img')
 

--- a/src/domains/my/detail/components/MyDraftsList.jsx
+++ b/src/domains/my/detail/components/MyDraftsList.jsx
@@ -2,10 +2,12 @@ import PropTypes from 'prop-types'
 import useFreeDraftStore from '../../../../store/mypage/useFreeDraftStore'
 import BoardCategory from './../../../../components/web/BoardCategory'
 import { BsCardImage } from 'react-icons/bs'
+import PostSortDropDown from '../../../../components/common/PostSortDropDown'
+import { useMemo, useState } from 'react'
 
 const MyDraftsList = ({ draftsListData, onDraftClick }) => {
   const { deleteFreeDraft } = useFreeDraftStore()
-
+  const [sort, setSort] = useState('latest')
   const getPreviewText = (text) => {
     if (!text) return '내용 없음'
 
@@ -27,9 +29,22 @@ const MyDraftsList = ({ draftsListData, onDraftClick }) => {
         return { label: '기타', bgColor: '#cecece', labelColor: '#2e2e2e', width: '60px' }
     }
   }
+  const sortedDrafts = useMemo(() => {
+    console.log('draftsListData', draftsListData)
 
+    return draftsListData.sort((a, b) => {
+      return sort === 'latest'
+        ? new Date(b.date) - new Date(a.date)
+        : new Date(a.date) - new Date(b.date)
+    })
+  }, [sort])
   return (
     <div className='w-full sm:max-w-[940px] mx-auto px-4 sm:px-10'>
+      {sortedDrafts.length > 0 && (
+        <div className='flex justify-end mx-auto'>
+          <PostSortDropDown onSortChange={setSort} />
+        </div>
+      )}
       {draftsListData.length === 0 ? (
         <p className='text-center text-dark-gray'>임시 저장된 글이 없습니다.</p>
       ) : (

--- a/src/domains/my/detail/components/MyDraftsList.jsx
+++ b/src/domains/my/detail/components/MyDraftsList.jsx
@@ -20,13 +20,13 @@ const MyDraftsList = ({ draftsListData, onDraftClick }) => {
   const getCategoryProps = (draftType) => {
     switch (draftType) {
       case 'community':
-        return { label: '자유게시판', bgColor: '#ECFDF5', labelColor: '#065F46', width: '80px' }
+        return { label: '자유게시판' }
       case 'jobPostings':
-        return { label: '구인', bgColor: '#EBF7FF', labelColor: '#2563EB', width: '60px' }
+        return { label: '구인' }
       case 'jobSeekings':
-        return { label: '구직', bgColor: '#FFEFEB', labelColor: '#DC2626', width: '60px' }
+        return { label: '구직' }
       default:
-        return { label: '기타', bgColor: '#cecece', labelColor: '#2e2e2e', width: '60px' }
+        return { label: '기타' }
     }
   }
   const sortedDrafts = useMemo(() => {

--- a/src/domains/my/detail/components/PostList.jsx
+++ b/src/domains/my/detail/components/PostList.jsx
@@ -7,13 +7,14 @@ import { deleteMyFreeBoardData, deleteMyJobBoardData } from '../../services/useM
 import useMyBoardStore from '../../../../store/mypage/useMyBoardStore'
 import ToastService from '../../../../utils/toastService'
 import useWriteModalStore from '../../../../store/modal/useWriteModalStore'
+import { useQueryClient } from '@tanstack/react-query'
 
-const PostList = () => {
+const PostList = ({ boardData }) => {
   const [checkedItems, setCheckedItems] = useState([])
-  const { freeBoard, jobBoard, fetchFreeBoard, fetchJobBoard } = useMyBoardStore()
   const { choiceBoard } = useBoardStore()
+  const { resetBoard } = useMyBoardStore()
   const { setShowModal } = useWriteModalStore()
-  const boardData = choiceBoard === '구인구직' ? jobBoard : freeBoard
+  const queryClient = useQueryClient()
 
   const toggleCheck = (id) => {
     setCheckedItems((prev) =>
@@ -35,12 +36,15 @@ const PostList = () => {
           recruitmentCategory: item.recruitmentCategory || 'JOB_POSTING',
         }))
         response = await deleteMyJobBoardData(deleteRequest)
+        ToastService.success('성공적으로 삭제되었습니다.1')
       } else {
         response = await deleteMyFreeBoardData(items)
+        ToastService.success('성공적으로 삭제되었습니다.2')
       }
       if (response && response.message === 'success') {
         setCheckedItems([])
-        await (isJobBoard ? fetchJobBoard(true) : fetchFreeBoard(true))
+        resetBoard(isJobBoard ? 'job' : 'free')
+        queryClient.invalidateQueries(['myPosts', choiceBoard])
       } else {
         ToastService.info('삭제에 실패했습니다.')
       }
@@ -51,6 +55,7 @@ const PostList = () => {
       useMyBoardStore.setState({ [isJobBoard ? 'isJobLoading' : 'isFreeLoading']: false })
     }
   }
+
   const handleDeleteItem = (id, title, recruitmentCategory) => {
     if (
       window.confirm(
@@ -194,6 +199,7 @@ const PostList = () => {
     </div>
   )
 }
+
 PostList.propTypes = {
   boardData: PropTypes.arrayOf(
     PropTypes.shape({
@@ -207,4 +213,5 @@ PostList.propTypes = {
     }),
   ).isRequired,
 }
+
 export default PostList

--- a/src/domains/my/detail/components/PostList.jsx
+++ b/src/domains/my/detail/components/PostList.jsx
@@ -16,6 +16,7 @@ const PostList = ({ boardData }) => {
   const { resetBoard } = useMyBoardStore()
   const { setShowModal } = useWriteModalStore()
   const queryClient = useQueryClient()
+  const [sort, setSort] = useState('latest')
 
   const toggleCheck = (id) => {
     setCheckedItems((prev) =>
@@ -86,17 +87,7 @@ const PostList = ({ boardData }) => {
       deleteItems(items, choiceBoard === '구인구직')
     }
   }
-  const [sort, setSort] = useState('latest')
 
-  // const sortedBoardData = useMemo(() => {
-  //   return boardData.sort((a, b) => {
-  //     return sort === 'latest'
-  //       ? new Date(a.createdAt) - new Date(b.createdAt)
-  //       : new Date(b.createdAt) - new Date(a.createdAt)
-  //   })
-  // }, [sort])
-
-  // 정렬된 데이터 계산
   const sortedBoardData = useMemo(() => {
     return [...boardData].sort((a, b) => {
       const dateA = new Date(a.createdAt)
@@ -105,7 +96,6 @@ const PostList = ({ boardData }) => {
     })
   }, [boardData, sort])
 
-  // 날짜 헤더 클릭 시 정렬 토글
   const handleSortToggle = () => {
     setSort((prev) => (prev === 'latest' ? 'oldest' : 'latest'))
   }

--- a/src/domains/my/detail/components/PostList.jsx
+++ b/src/domains/my/detail/components/PostList.jsx
@@ -1,5 +1,5 @@
 import commentImg from '../../../../assets/icons/common/comment.svg'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import useBoardStore from '../../../../store/mypage/useBoardStore'
 import BoardCategory from '../../../../components/web/BoardCategory'
 import PropTypes from 'prop-types'
@@ -8,6 +8,7 @@ import useMyBoardStore from '../../../../store/mypage/useMyBoardStore'
 import ToastService from '../../../../utils/toastService'
 import useWriteModalStore from '../../../../store/modal/useWriteModalStore'
 import { useQueryClient } from '@tanstack/react-query'
+import PostSortDropDown from '../../../../components/common/PostSortDropDown'
 
 const PostList = ({ boardData }) => {
   const [checkedItems, setCheckedItems] = useState([])
@@ -36,10 +37,10 @@ const PostList = ({ boardData }) => {
           recruitmentCategory: item.recruitmentCategory || 'JOB_POSTING',
         }))
         response = await deleteMyJobBoardData(deleteRequest)
-        ToastService.success('성공적으로 삭제되었습니다.1')
+        ToastService.success('성공적으로 삭제되었습니다.')
       } else {
         response = await deleteMyFreeBoardData(items)
-        ToastService.success('성공적으로 삭제되었습니다.2')
+        ToastService.success('성공적으로 삭제되었습니다.')
       }
       if (response && response.message === 'success') {
         setCheckedItems([])
@@ -85,6 +86,29 @@ const PostList = ({ boardData }) => {
       deleteItems(items, choiceBoard === '구인구직')
     }
   }
+  const [sort, setSort] = useState('latest')
+
+  // const sortedBoardData = useMemo(() => {
+  //   return boardData.sort((a, b) => {
+  //     return sort === 'latest'
+  //       ? new Date(a.createdAt) - new Date(b.createdAt)
+  //       : new Date(b.createdAt) - new Date(a.createdAt)
+  //   })
+  // }, [sort])
+
+  // 정렬된 데이터 계산
+  const sortedBoardData = useMemo(() => {
+    return [...boardData].sort((a, b) => {
+      const dateA = new Date(a.createdAt)
+      const dateB = new Date(b.createdAt)
+      return sort === 'latest' ? dateB - dateA : dateA - dateB
+    })
+  }, [boardData, sort])
+
+  // 날짜 헤더 클릭 시 정렬 토글
+  const handleSortToggle = () => {
+    setSort((prev) => (prev === 'latest' ? 'oldest' : 'latest'))
+  }
 
   return (
     <div>
@@ -116,21 +140,25 @@ const PostList = ({ boardData }) => {
             <th>No</th>
             <th>제목</th>
             <th>
-              날짜 <span className='text-[10px]'>▲</span>
+              <button onClick={handleSortToggle}>
+                <PostSortDropDown onSortChange={setSort} className='hidden' />
+                날짜 <span className='text-[10px]'>{sort === 'latest' ? '▲' : '▼'}</span>
+              </button>
             </th>
-            {Array.isArray(boardData) &&
-              boardData.some((item) => item.recruitmentCategory !== undefined) && <th>카테고리</th>}
-            {Array.isArray(boardData) &&
-              boardData.some((item) => item.commentCount !== undefined) && <th>댓글</th>}
-            {Array.isArray(boardData) && boardData.some((item) => item.viewCount !== undefined) && (
-              <th>조회수</th>
-            )}
+            {Array.isArray(sortedBoardData) &&
+              sortedBoardData.some((item) => item.recruitmentCategory !== undefined) && (
+                <th>카테고리</th>
+              )}
+            {Array.isArray(sortedBoardData) &&
+              sortedBoardData.some((item) => item.commentCount !== undefined) && <th>댓글</th>}
+            {Array.isArray(sortedBoardData) &&
+              sortedBoardData.some((item) => item.viewCount !== undefined) && <th>조회수</th>}
             <th>삭제</th>
           </tr>
         </thead>
         <tbody>
-          {Array.isArray(boardData) && boardData.length > 0 ? (
-            boardData.map((item, index) => (
+          {Array.isArray(sortedBoardData) && sortedBoardData.length > 0 ? (
+            sortedBoardData.map((item, index) => (
               <tr key={item.boardId || item.recruitmentId} className='h-12 border-b'>
                 <td>
                   <input

--- a/src/domains/my/detail/components/RecentList.jsx
+++ b/src/domains/my/detail/components/RecentList.jsx
@@ -1,0 +1,52 @@
+const RecentList = () => {
+  return (
+    <div className='w-full sm:max-w-[940px] mx-auto px-4 sm:px-10'>
+      {draftsListData.length === 0 ? (
+        <p className='text-center text-dark-gray'>최근본 목록이 없습니다.</p>
+      ) : (
+        draftsListData.map((item) => {
+          const previewText = getPreviewText(item.text)
+          const hasImage = item.text && item.text.includes('<img')
+
+          return (
+            <div
+              key={item.id}
+              onClick={() => onDraftClick(item)}
+              className='pt-8 cursor-pointer sm:pt-10 '
+            >
+              <div className='flex pb-5 sm:pb-[30px] items-center justify-between'>
+                <div className='sm:text-[26px] font-semibold text-[20px]'>
+                  {item.title || '제목 없음'}
+                </div>
+                <BoardCategory {...getCategoryProps(item.draftType || 'community')} />
+              </div>
+              <div className='flex items-center text-base sm:text-xl text-dark-gray text-start'>
+                {hasImage && previewText === '내용 없음' ? '' : previewText}
+                {hasImage && (
+                  <div>
+                    <BsCardImage className='inline-block mx-2 text-xl sm:text-2xl' /> 이미지
+                  </>
+                )}
+              </div>
+              <div className='flex justify-between py-3 sm:py-6'>
+                <span className='text-main-pink sm:text-[20px] text-[14px]'>{item.date}</span>
+                <span
+                  className='text-dark-gray sm:text-[20px] text-[14px] px-3 py-1 rounded-[5px] hover:bg-main-pink/10 transition'
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    deleteFreeDraft(item.id)
+                  }}
+                >
+                  삭제
+                </span>
+              </div>
+              <div className='border border-light-gray'></div>
+            </div>
+          )
+        })
+      )}
+    </div>
+  )
+}
+
+export default RecentList

--- a/src/domains/my/detail/components/RecentList.jsx
+++ b/src/domains/my/detail/components/RecentList.jsx
@@ -1,50 +1,59 @@
-const RecentList = () => {
+import { useNavigate } from 'react-router-dom'
+import WorkBoard from '../../../../components/web/WorkBoard'
+import getExperienceLabel from '../../../job/common/utils/getExperienceLabel'
+import FreeBoard from '../../../../components/web/FreeBoard'
+
+const RecentList = ({ sortedPosts }) => {
+  const navigate = useNavigate()
+  const formatDate = (dateStr) => (dateStr ? dateStr.slice(0, 10) : '')
+
   return (
     <div className='w-full sm:max-w-[940px] mx-auto px-4 sm:px-10'>
-      {draftsListData.length === 0 ? (
-        <p className='text-center text-dark-gray'>최근본 목록이 없습니다.</p>
-      ) : (
-        draftsListData.map((item) => {
-          const previewText = getPreviewText(item.text)
-          const hasImage = item.text && item.text.includes('<img')
-
-          return (
-            <div
-              key={item.id}
-              onClick={() => onDraftClick(item)}
-              className='pt-8 cursor-pointer sm:pt-10 '
-            >
-              <div className='flex pb-5 sm:pb-[30px] items-center justify-between'>
-                <div className='sm:text-[26px] font-semibold text-[20px]'>
-                  {item.title || '제목 없음'}
-                </div>
-                <BoardCategory {...getCategoryProps(item.draftType || 'community')} />
-              </div>
-              <div className='flex items-center text-base sm:text-xl text-dark-gray text-start'>
-                {hasImage && previewText === '내용 없음' ? '' : previewText}
-                {hasImage && (
-                  <div>
-                    <BsCardImage className='inline-block mx-2 text-xl sm:text-2xl' /> 이미지
-                  </>
-                )}
-              </div>
-              <div className='flex justify-between py-3 sm:py-6'>
-                <span className='text-main-pink sm:text-[20px] text-[14px]'>{item.date}</span>
-                <span
-                  className='text-dark-gray sm:text-[20px] text-[14px] px-3 py-1 rounded-[5px] hover:bg-main-pink/10 transition'
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    deleteFreeDraft(item.id)
-                  }}
-                >
-                  삭제
-                </span>
-              </div>
-              <div className='border border-light-gray'></div>
-            </div>
-          )
-        })
-      )}
+      <div className='sm:grid grid-cols-1 lg:grid-cols-3 sm:grid-cols-2 gap-4 max-w-[932px] mx-auto justify-items-center px-4'>
+        {sortedPosts.map((post) =>
+          post.draftType !== 'community' ? (
+            <WorkBoard
+              key={post.id}
+              postId={post.id}
+              title={post.title}
+              name={post.nickname}
+              date={formatDate(post.createdAt)}
+              like={post.like || false}
+              popular1={post.popular1 || false}
+              joboffer1={post.draftType === 'jobPostings' || false}
+              experienceLabel={
+                getExperienceLabel(post.experienceMin, post.experienceMax) ||
+                getExperienceLabel(post.experience)
+              }
+              jobsearch1={post.draftType === 'jobSeekings' || false}
+              othersite1={post.othersite1 || false}
+              worktype1={post.worktype1 || post.employmentType}
+              employmentType={post.employmentType}
+              view={post.viewCount || post.view}
+              type={post.draftType ? 'jobPostings' : post.draftType ? 'jobSeekings' : 'community'}
+              onClick={() => {
+                const id = post.id
+                if (post.draftType === 'jobPostings') {
+                  navigate(`/job/recruitment/post/${id}`)
+                } else {
+                  navigate(`/job/job-seek/post/${id}`)
+                }
+              }}
+            />
+          ) : (
+            <FreeBoard
+              key={post.id}
+              boardId={post.id}
+              title={post.title}
+              content={post.text}
+              name={post.nickname}
+              date={formatDate(post.createdAt)}
+              commentCount={post.commentCount}
+              viewCount={post.viewCount}
+            />
+          ),
+        )}
+      </div>
     </div>
   )
 }

--- a/src/domains/my/detail/components/RecentList.jsx
+++ b/src/domains/my/detail/components/RecentList.jsx
@@ -30,7 +30,7 @@ const RecentList = ({ sortedPosts }) => {
               worktype1={post.worktype1 || post.employmentType}
               employmentType={post.employmentType}
               view={post.viewCount || post.view}
-              type={post.draftType ? 'jobPostings' : post.draftType ? 'jobSeekings' : 'community'}
+              type={post.draftType || 'community'}
               onClick={() => {
                 const id = post.id
                 if (post.draftType === 'jobPostings') {

--- a/src/domains/my/detail/components/saveToStorage.jsx
+++ b/src/domains/my/detail/components/saveToStorage.jsx
@@ -1,0 +1,39 @@
+import DOMPurify from 'dompurify'
+
+const saveTOStorage = (postData, id, draftType) => {
+  const recentList = JSON.parse(sessionStorage.getItem('RecentListSave')) || []
+
+  const newItem = {
+    id,
+    title: postData.title || '제목 없음',
+    text: postData.text
+      ? DOMPurify.sanitize(postData.text, { ALLOWED_TAGS: [] }).slice(0, 30)
+      : '내용 없음',
+    draftType: draftType || 'community',
+    date: new Date().toISOString(),
+    ...(postData.viewCount && { viewCount: postData.viewCount }),
+    ...(postData.createdAt && { createdAt: postData.createdAt }),
+    ...(postData.commentCount && { commentCount: postData.commentCount }),
+    ...(postData.nickname && { nickname: postData.nickname }),
+    ...(postData.isAuthentic && { isAuthentic: postData.isAuthentic }),
+    ...(postData.employmentType && { employmentType: postData.employmentType }),
+    ...(postData.experience && { experience: postData.experience }),
+    ...(postData.jobCategory && { jobCategory: postData.jobCategory }),
+    ...(postData.experienceMin && { experienceMin: postData.experienceMin }),
+    ...(postData.experienceMax && { experienceMax: postData.experienceMax }),
+    ...(postData.location && { location: postData.location }),
+    ...(postData.closingDate && { closingDate: postData.closingDate }),
+    ...(postData.websiteUrl && { websiteUrl: postData.websiteUrl }),
+    ...(postData.contactEmail && { contactEmail: postData.contactEmail }),
+  }
+
+  const updatedList = [newItem, ...recentList.filter((item) => item.id !== id)].slice(0, 30)
+
+  try {
+    sessionStorage.setItem('RecentListSave', JSON.stringify(updatedList))
+  } catch (e) {
+    console.error('스토리지 저장 실패:', e)
+  }
+}
+
+export { saveTOStorage }

--- a/src/domains/my/mypage/components/MyActivity.jsx
+++ b/src/domains/my/mypage/components/MyActivity.jsx
@@ -9,7 +9,7 @@ const MyActivity = () => {
     { icon: pencil, text: '내가 작성한 글', alt: 'pencil', link: ROUTER_PATHS.MY_POST },
     { icon: hand, text: '임시 저장 글', alt: 'hand', link: ROUTER_PATHS.MY_DRAFTS },
     { icon: scrap, text: '스크랩', alt: 'scrap', link: ROUTER_PATHS.MY_SCRAP },
-    { icon: latest, text: '최근본 목록', alt: 'latest', link: ROUTER_PATHS.FIND_PW },
+    { icon: latest, text: '최근본 목록', alt: 'latest', link: ROUTER_PATHS.MY_RECENT_LIST },
   ]
 
   const navigate = useNavigate()

--- a/src/routes/RouterPath.js
+++ b/src/routes/RouterPath.js
@@ -27,6 +27,7 @@ const ROUTER_PATHS = {
   MY_PW_MIS: '/my-page/password-mis',
   MY_SCRAP: '/my-page/my-scrap',
   MY_POST: '/my-page/my-post',
+  MY_RECENT_LIST: '/my-page/my-recent-list',
   MY_DRAFTS: '/my-page/my-drafts',
   ERROR: '/error',
   KAKAO_SUCCESS: '/login/kakao/success',

--- a/src/routes/routes.jsx
+++ b/src/routes/routes.jsx
@@ -136,6 +136,7 @@ const routes = [
   {
     path: ROUTER_PATHS.FIND_PW_CHANGE_PW,
     element: <ChangePwPage />,
+    label: '비밀번호 변경',
   },
   {
     path: ROUTER_PATHS.MY_PAGE,

--- a/src/routes/routes.jsx
+++ b/src/routes/routes.jsx
@@ -29,6 +29,7 @@ import EditRecruitmentPost from '../domains/job/recruitment/edit/page/EditRecrui
 import EditJobSeekPostPage from '../domains/job/search/edit/page/EditJobSeekPostPage'
 import KakaoSuccess from '../domains/login/page/KakaoSuccess'
 import NaverSuccess from '../domains/login/page/NaverSuccess'
+import MyRecentList from '../domains/my/detail/MyRecentList'
 
 const routes = [
   {
@@ -169,6 +170,12 @@ const routes = [
     path: ROUTER_PATHS.MY_POST,
     element: <MyPost />,
     label: '내가 작성한 글',
+    noMargin: true,
+  },
+  {
+    path: ROUTER_PATHS.MY_RECENT_LIST,
+    element: <MyRecentList />,
+    label: '최근본 목록',
     noMargin: true,
   },
   {

--- a/src/services/api/axios.js
+++ b/src/services/api/axios.js
@@ -31,7 +31,7 @@ authApi.interceptors.request.use(
     if (token) {
       config.headers['Authorization'] = token
     }
-    console.log('Sending request:', config.url)
+    // console.log('Sending request:', config.url)
     return config
   },
   (error) => {

--- a/src/store/mypage/useMyBoardStore.js
+++ b/src/store/mypage/useMyBoardStore.js
@@ -1,55 +1,76 @@
 import { create } from 'zustand'
 import { getMyFreeBoardData, getMyJobBoardData } from '../../domains/my/services/useMyBoardServices'
 
-const useMyBoardStore = create((set) => ({
+const useMyBoardStore = create((set, get) => ({
   freeBoard: [],
   jobBoard: [],
   isFreeLoading: false,
   isJobLoading: false,
   freeError: null,
   jobError: null,
+  freePage: 0,
+  jobPage: 0,
+  hasMoreFree: true,
+  hasMoreJob: true,
 
-  fetchBoardData: async (boardType, fetchService, dataExtractor, force = false) => {
+  fetchBoardData: async (boardType, fetchService, dataExtractor, page = 0, limit = 10) => {
     const stateKey = boardType === 'free' ? 'freeBoard' : 'jobBoard'
     const loadingKey = boardType === 'free' ? 'isFreeLoading' : 'isJobLoading'
     const errorKey = boardType === 'free' ? 'freeError' : 'jobError'
+    const pageKey = boardType === 'free' ? 'freePage' : 'jobPage'
+    const hasMoreKey = boardType === 'free' ? 'hasMoreFree' : 'hasMoreJob'
     const boardName = boardType === 'free' ? '자유게시판' : '구인구직'
 
-    if (force || useMyBoardStore.getState()[stateKey].length === 0) {
-      set({ [loadingKey]: true, [errorKey]: null })
+    set({ [loadingKey]: true, [errorKey]: null })
 
-      try {
-        const response = await fetchService()
-        if (response.message === 'success') {
-          set({ [stateKey]: dataExtractor(response.data) || [] })
-        } else {
-          set({
-            [errorKey]: `${boardName} 리스트를 불러오지 못했습니다.`,
-            [stateKey]: [],
-          })
-        }
-      } catch (error) {
-        console.error(`내가 작성한 ${boardName} 리스트 오류:`, error)
+    try {
+      const response = await fetchService(page, limit)
+      if (response.message === 'success') {
+        const newData = dataExtractor(response.data) || []
+        set((state) => ({
+          [stateKey]: page === 0 ? newData : [...state[stateKey], ...newData],
+          [pageKey]: page,
+          [hasMoreKey]: response.data.hasNext,
+        }))
+        return response
+      } else {
         set({
-          [errorKey]: error.response?.data?.message || '서버 오류가 발생했습니다.',
-          [stateKey]: [],
+          [errorKey]: `${boardName} 리스트를 불러오지 못했습니다.`,
+          [hasMoreKey]: false,
         })
-      } finally {
-        set({ [loadingKey]: false })
+        return { message: 'error', data: { hasNext: false } }
       }
+    } catch (error) {
+      console.error(`내가 작성한 ${boardName} 리스트 오류:`, error)
+      set({
+        [errorKey]: error.message || '서버 오류가 발생했습니다.',
+        [hasMoreKey]: false,
+      })
+      return { message: 'error', data: { hasNext: false } }
+    } finally {
+      set({ [loadingKey]: false })
     }
   },
 
-  fetchFreeBoard: async (force = false) => {
-    return useMyBoardStore
-      .getState()
-      .fetchBoardData('free', getMyFreeBoardData, (data) => data.myPostingsInBoardList, force)
+  fetchFreeBoard: async (page = 0, limit = 10) => {
+    return get().fetchBoardData(
+      'free',
+      getMyFreeBoardData,
+      (data) => data.myPostingsInBoardList,
+      page,
+      limit,
+    )
   },
 
-  fetchJobBoard: async (force = false) => {
-    return useMyBoardStore
-      .getState()
-      .fetchBoardData('job', getMyJobBoardData, (data) => data.postings, force)
+  fetchJobBoard: async (page = 0, limit = 10) => {
+    return get().fetchBoardData('job', getMyJobBoardData, (data) => data.postings, page, limit)
+  },
+
+  resetBoard: (boardType) => {
+    const stateKey = boardType === 'free' ? 'freeBoard' : 'jobBoard'
+    const pageKey = boardType === 'free' ? 'freePage' : 'jobPage'
+    const hasMoreKey = boardType === 'free' ? 'hasMoreFree' : 'hasMoreJob'
+    set({ [stateKey]: [], [pageKey]: 0, [hasMoreKey]: true })
   },
 }))
 

--- a/src/stories/BoardCategory.stories.jsx
+++ b/src/stories/BoardCategory.stories.jsx
@@ -11,23 +11,10 @@ export default {
 const Template = (args) => <BoardCategory {...args} />
 
 export const Default = Template.bind({})
-Default.args = {
-  label: '자유게시판',
-  bgColor: '#ECFDF5',
-}
+Default.args = { label: '자유게시판' }
 
 export const 구인 = Template.bind({})
-구인.args = {
-  label: '구인',
-  bgColor: '#EBF7FF',
-  labelColor: '#2563EB',
-  width: '60px',
-}
+구인.args = { label: '구인' }
 
 export const 구직 = Template.bind({})
-구직.args = {
-  label: '구직',
-  bgColor: '#FFEFEB',
-  labelColor: '#DC2626',
-  width: '60px',
-}
+구직.args = { label: '구직' }


### PR DESCRIPTION
## #️⃣연관된 이슈

#195 

### 📝작업 내용

- [x] 내가 작성한 글 무한스크롤 기능 추가
- [x] 최근본 목록 추가 기능 추가
- [x] 비밀번호 변경 페이지 반응형 변경
- [x] 임시저장 최신글 위로

최근본 목록 세션스토리지에 저장으로 최대 30개 확인 가능 
단 로그아웃시 초기화 

### 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/bf26748c-b785-4b4f-8089-e4a6b0f7c316)

![image](https://github.com/user-attachments/assets/89b9d8a3-7d41-4dc7-b6f2-2f06f763f49f)
![image](https://github.com/user-attachments/assets/a2c8b0ba-31a4-4536-a1d4-2d4336bed35b)
![image](https://github.com/user-attachments/assets/81969552-d2fa-44e1-8cc7-5929ee4df4fd)

### 💬리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 최근 본 게시글 목록 페이지가 추가되었습니다. 최대 30개의 최근 게시글을 확인하고 정렬할 수 있습니다.
  * 최근 본 게시글은 각 상세 페이지 방문 시 자동으로 저장됩니다.

* **기능 개선**
  * 내 게시글 목록에 무한 스크롤 및 정렬 기능이 추가되어 더 편리하게 게시글을 탐색할 수 있습니다.
  * 임시 저장글, 게시글 목록, 최근 본 목록에서 최신순/오래된순 정렬 기능이 제공됩니다.
  * 비밀번호 입력란의 안내 문구가 더 간결하게 변경되었습니다.
  * 게시글 카테고리 스타일이 일관성 있게 개선되었습니다.

* **버그 수정 및 스타일**
  * 일부 버튼 및 레이아웃의 CSS 클래스 순서가 정리되어 UI 일관성이 향상되었습니다.

* **기타**
  * 라우터 및 네비게이션 경로가 최근 본 목록 등 새로운 기능에 맞게 추가 및 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->