### PR TITLE
[publishing-24/style] 전체 디자인 수정

### DIFF
--- a/src/components/web/PwInputBox.jsx
+++ b/src/components/web/PwInputBox.jsx
@@ -26,9 +26,9 @@ const PwInputBox = forwardRef(({ placeholder, size = 'medium', ...rest }, ref) =
         onClick={() => setShowPassword(!showPassword)}
       >
         {showPassword ? (
-          <img src={viewPink} className='w-6 h-6' alt='조회수 아이콘 (활성)' />
+          <img src={viewPink} className='w-6 h-6' alt='비밀번호 표시' />
         ) : (
-          <img src={viewGray} className='w-6 h-6' alt='조회수 아이콘 (비활성)' />
+          <img src={viewGray} className='w-6 h-6' alt='비밀번호 숨김' />
         )}
       </button>
     </div>

--- a/src/components/web/PwInputBox.jsx
+++ b/src/components/web/PwInputBox.jsx
@@ -16,7 +16,7 @@ const PwInputBox = forwardRef(({ placeholder, size = 'medium', ...rest }, ref) =
       <input
         type={showPassword ? 'text' : 'password'}
         placeholder={placeholder}
-        className={`${PwInputBoxSize[size]} border border-dark-gray rounded pl-4 pr-12 sm:text-base text-sm text-black placeholder:text-dark-gray focus:border-main-pink focus:outline-none`}
+        className={`${PwInputBoxSize[size]} border border-dark-gray rounded pl-4 pr-12 text-[18px] text-black placeholder:text-dark-gray focus:border-main-pink focus:outline-none`}
         ref={ref}
         {...rest}
       />
@@ -26,9 +26,9 @@ const PwInputBox = forwardRef(({ placeholder, size = 'medium', ...rest }, ref) =
         onClick={() => setShowPassword(!showPassword)}
       >
         {showPassword ? (
-          <img src={viewPink} className='w-6 h-6' />
+          <img src={viewPink} className='w-6 h-6' alt='조회수 아이콘 (활성)' />
         ) : (
-          <img src={viewGray} className='w-6 h-6' />
+          <img src={viewGray} className='w-6 h-6' alt='조회수 아이콘 (비활성)' />
         )}
       </button>
     </div>

--- a/src/constants/animations.js
+++ b/src/constants/animations.js
@@ -1,5 +1,5 @@
 export const CELEBRATION_CONFETTI = {
   particleCount: 200,
   spread: 360,
-  origin: { x: 0.2, y: 0.7 },
+  origin: { x: 0.5, y: 0.7 },
 }

--- a/src/domains/login/common/components/LoginForm.jsx
+++ b/src/domains/login/common/components/LoginForm.jsx
@@ -111,7 +111,7 @@ const LoginForm = () => {
           <p className='flex items-start ml-4 text-red-500'>{errors.userID.message}</p>
         )}
         <div className='flex w-full mt-7'>
-          <InputBox
+          <PwInputBox
             placeholder='비밀번호'
             size='big'
             {...register('password', { required: '비밀번호를 입력하세요' })}

--- a/src/domains/login/common/components/LoginForm.jsx
+++ b/src/domains/login/common/components/LoginForm.jsx
@@ -111,7 +111,7 @@ const LoginForm = () => {
           <p className='flex items-start ml-4 text-red-500'>{errors.userID.message}</p>
         )}
         <div className='flex w-full mt-7'>
-          <PwInputBox
+          <InputBox
             placeholder='비밀번호'
             size='big'
             {...register('password', { required: '비밀번호를 입력하세요' })}

--- a/src/domains/main/common/components/BoardButton.jsx
+++ b/src/domains/main/common/components/BoardButton.jsx
@@ -39,7 +39,7 @@ const BoardButton = ({ onBoardSelect, selectedBoard, handleRefresh }) => {
           className='flex items-center justify-end w-full mt-1 '
         >
           <div className='w-3 h-3 mr-1 mb-[1px] sm:w-4 sm:h-4'>
-            <img src={commonTime} alt='commonTime w-3 h-3' />
+            <img src={commonTime} alt='commonTime' className='w-3 h-3' />
           </div>
           <p className='text-sm font-semibold sm:text-base text-dark-gray hover:text-light-gray'>
             {formattedDate} 기준

--- a/src/domains/my/detail/MyPost.jsx
+++ b/src/domains/my/detail/MyPost.jsx
@@ -44,7 +44,7 @@ const MyPost = () => {
             <Spinner size={48} color='main-pink' />
           </div>
         ) : posts.length === 0 ? (
-          <p className='text-dark-gray'>작성 글이 없습니다.</p>
+          <p className='text-dark-gray mt-12'>첫 글을 작성해보세요! </p>
         ) : (choiceBoard === '자유게시판' ? freeError : jobError) ? (
           <div className='flex flex-col text-center text-red-500'>
             {choiceBoard === '자유게시판' ? freeError : jobError}

--- a/src/domains/my/detail/components/PostList.jsx
+++ b/src/domains/my/detail/components/PostList.jsx
@@ -105,14 +105,10 @@ const PostList = ({ boardData }) => {
       <div className='sm:text-[30px] font-bold flex justify-start mb-[20px] mt-10 text-[20px]'>
         {choiceBoard === '구인구직' ? '구인 | 구직' : '자유게시판'}
       </div>
-      <div className='flex flex-row justify-between my-3'>
-        <div className='flex gap-3'>
-          <input type='checkbox' checked={isAllChecked} onChange={toggleAll} />
-          전체 선택
-        </div>
+      <div className='flex flex-row justify-end my-3'>
         <div className='flex gap-2'>
           <button onClick={handleDeleteSelected} className='text-dark-gray'>
-            선택삭제
+            삭제
           </button>
           <div className='text-dark-gray'>|</div>
           <button className='text-main-pink' onClick={() => setShowModal(true)}>
@@ -124,7 +120,7 @@ const PostList = ({ boardData }) => {
       <table className='w-full text-sm'>
         <thead className='border-b'>
           <tr className='h-12'>
-            <th>
+            <th className='w-10'>
               <input type='checkbox' checked={isAllChecked} onChange={toggleAll} />
             </th>
             <th>No</th>


### PR DESCRIPTION
## #️⃣연관된 이슈

#204 

### 📝작업 내용

- [x] 폭죽 위치 수정 
- [x] 아이디 & 비밀번호 폰트 크기 다름
- [x] 작성 글이 없습니다 위치 수정
- [x] 내가 작성한 글 디자인 수정
- [x] 모든 이미지 & 아이콘에 alt 추가

### 📸 스크린샷 (선택)

<img width="1439" alt="스크린샷 2025-06-30 오후 2 09 12" src="https://github.com/user-attachments/assets/75d8f854-1e13-4fc1-912e-b81e233f2000" />

-----
<img width="1440" alt="스크린샷 2025-06-30 오후 2 09 22" src="https://github.com/user-attachments/assets/b3cd0ffe-47e0-4138-b4c9-7548ad9dc691" />

----

<img width="1440" alt="스크린샷 2025-06-30 오후 2 09 40" src="https://github.com/user-attachments/assets/c8eff90f-28d8-4a1e-a69a-16cd34eeb550" />

### 💬리뷰 요구사항(선택)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **스타일**
  * 비밀번호 입력창의 글자 크기가 고정(18px)으로 변경되었습니다.
  * 비밀번호 표시 토글 버튼 이미지에 더 명확한 대체 텍스트(alt)가 추가되었습니다.
  * 새로고침 버튼 이미지의 alt 텍스트가 간결해지고, 이미지 크기 스타일이 클래스에 적용되었습니다.

* **UI 개선**
  * 게시글이 없을 때 표시되는 메시지가 "첫 글을 작성해보세요!"로 변경되고, 상단 여백이 추가되었습니다.
  * 게시글 목록 상단의 전체 선택 체크박스와 라벨이 제거되고, 삭제 버튼이 오른쪽으로 정렬되며, 버튼명이 "삭제"로 간소화되었습니다.
  * 게시글 테이블 헤더의 전체 선택 체크박스에 고정 너비가 적용되었습니다.

* **애니메이션**
  * 축하 콘페티 효과의 시작 위치가 화면 중앙으로 조정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->