### PR TITLE
[feature-36/feat] 이용약관 & 개인정보 연결하기 | 구인 마감 인풋박스 가운데 | 구글 검색 했을 때 아이콘 수정하기 | meta-tag 수정 완료

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,8 +31,8 @@
       property="og:description"
       content="출판업계 종사자를 위한 구인·구직 플랫폼, 북잡. 채용 정보부터 자유게시판까지 업계 사람들과 소통하세요."
     />
-    <meta property="og:image" content="/metatag.png" />
-    <meta property="og:url" content="https://book-job.co.kr" />
+    <meta property="og:image" content="https://www.bookjob.co.kr/metatag.png" />
+    <meta property="og:url" content="https://www.bookjob.co.kr" />
     <meta property="og:type" content="website" />
 
     <meta name="twitter:card" content="summary_large_image" />
@@ -41,7 +41,7 @@
       name="twitter:description"
       content="출판업계 종사자를 위한 구인·구직 플랫폼, 북잡. 채용 정보부터 자유게시판까지 업계 사람들과 소통하세요."
     />
-    <meta name="twitter:image" content="/metatag.png" />
+    <meta name="twitter:image" content="https://www.bookjob.co.kr/metatag.png" />
 
     <script>
       window.global = window

--- a/src/components/web/Footer.jsx
+++ b/src/components/web/Footer.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import { useNavigate } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import ROUTER_PATHS from '../../routes/RouterPath'
 import useIsMobile from '../../hooks/header/useIsMobile'
 
@@ -21,7 +21,7 @@ const Footer = ({ email, onClick }) => {
         )}
         <div className='flex flex-wrap items-center gap-3 text-sm text-left sm:gap-6 text-dark-gray'>
           <span className='font-semibold'>북잡</span>
-          {/* <span>대표 | 이신지</span> */}
+          <span>대표 | 이신지</span>
           <span>
             이메일 |{' '}
             <a
@@ -34,12 +34,12 @@ const Footer = ({ email, onClick }) => {
             </a>
           </span>
           <span className='flex gap-3 sm:gap-6'>
-            <a href='/terms' className='text-blue-600 underline'>
+            <Link to='/terms-of-service' className='text-blue-600 underline'>
               이용약관
-            </a>
-            <a href='/privacy' className='text-blue-600 underline'>
+            </Link>
+            <Link to='/privacy-policy' className='text-blue-600 underline'>
               개인정보처리방침
-            </a>
+            </Link>
           </span>
         </div>
 

--- a/src/components/web/Footer.jsx
+++ b/src/components/web/Footer.jsx
@@ -16,10 +16,10 @@ const Footer = ({ email, onClick }) => {
         <div className='max-w-7xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-3 sm:gap-0'>
           <nav className='flex items-center gap-3 text-sm text-dark-gray select-none'>
             <span className='font-semibold cursor-default'>북잡 </span>
-            <Link to='/privacy-policy' className='text-blue-600 underline'>
+            <Link to='/privacy-policy' className='text-dark-gray underline'>
               개인정보처리방침
             </Link>
-            <Link to='/terms-of-service' className='text-blue-600 underline'>
+            <Link to='/terms-of-service' className='text-dark-gray underline'>
               이용약관
             </Link>
           </nav>
@@ -87,11 +87,11 @@ const Footer = ({ email, onClick }) => {
             </a>
           </span>
           <span className='flex gap-3 sm:gap-6'>
-            <Link to='/terms-of-service' className='text-blue-600 underline'>
-              이용약관
-            </Link>
-            <Link to='/privacy-policy' className='text-blue-600 underline'>
+            <Link to='/privacy-policy' className='text-dark-gray underline'>
               개인정보처리방침
+            </Link>
+            <Link to='/terms-of-service' className='text-dark-gray underline'>
+              이용약관
             </Link>
           </span>
         </div>

--- a/src/components/web/Footer.jsx
+++ b/src/components/web/Footer.jsx
@@ -1,27 +1,80 @@
 import PropTypes from 'prop-types'
 import { Link, useNavigate } from 'react-router-dom'
-import ROUTER_PATHS from '../../routes/RouterPath'
+import { useState } from 'react'
+import { MdArrowDropDown, MdArrowDropUp } from 'react-icons/md'
 import useIsMobile from '../../hooks/header/useIsMobile'
+import ROUTER_PATHS from '../../routes/RouterPath'
 
 const Footer = ({ email, onClick }) => {
-  const navigate = useNavigate()
   const isMobile = useIsMobile()
+  const navigate = useNavigate()
+  const [showCompanyInfo, setShowCompanyInfo] = useState(false)
+
+  if (isMobile) {
+    return (
+      <footer className='w-full bg-[#FDF8FA] py-5 px-6 text-center sm:text-left'>
+        <div className='max-w-7xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-3 sm:gap-0'>
+          <nav className='flex items-center gap-3 text-sm text-dark-gray select-none'>
+            <span className='font-semibold cursor-default'>북잡 </span>
+            <Link to='/privacy-policy' className='text-blue-600 underline'>
+              개인정보처리방침
+            </Link>
+            <Link to='/terms-of-service' className='text-blue-600 underline'>
+              이용약관
+            </Link>
+          </nav>
+          <div
+            className='flex items-center text-sm text-dark-gray cursor-pointer select-none'
+            onClick={() => setShowCompanyInfo((prev) => !prev)}
+            aria-expanded={showCompanyInfo}
+            aria-controls='company-info'
+            role='button'
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                setShowCompanyInfo((prev) => !prev)
+              }
+            }}
+          >
+            (주) 북잡
+            <span className='ml-1 text-lg leading-none'>
+              {showCompanyInfo ? <MdArrowDropUp /> : <MdArrowDropDown />}
+            </span>
+          </div>
+        </div>
+        {showCompanyInfo && (
+          <div
+            id='company-info'
+            className='max-w-7xl mx-auto mt-2 text-xs sm:text-sm text-gray-600 text-center sm:text-left space-y-1 select-text'
+          >
+            <p>대표 | 이신지</p>
+            <p>
+              이메일 |{' '}
+              <a href={`mailto:${email}`} className='text-blue-600 underline'>
+                {email}
+              </a>
+            </p>
+          </div>
+        )}
+        <div className='mt-4 text-xs text-dark-gray text-center sm:text-left'>
+          © 2025 BookJob. All rights reserved.
+        </div>
+      </footer>
+    )
+  }
 
   return (
     <footer className='w-full bg-[#FDF8FA] sm:py-10 py-5 px-6 text-left'>
       <div className='flex flex-col mx-auto sm:gap-4 max-w-7xl'>
-        {isMobile ? null : (
-          <button
-            type='button'
-            onClick={() => navigate(ROUTER_PATHS.MAIN_PAGE)}
-            className='text-3xl font-bold text-left cursor-pointer text-main-pink font-logo'
-          >
-            bookjob
-          </button>
-        )}
+        <button
+          type='button'
+          onClick={() => navigate(ROUTER_PATHS.MAIN_PAGE)}
+          className='text-3xl font-bold text-left cursor-pointer text-main-pink font-logo'
+        >
+          bookjob
+        </button>
         <div className='flex flex-wrap items-center gap-3 text-sm text-left sm:gap-6 text-dark-gray'>
           <span className='font-semibold'>북잡</span>
-          <span>대표 | 이신지</span>
           <span>
             이메일 |{' '}
             <a
@@ -34,16 +87,15 @@ const Footer = ({ email, onClick }) => {
             </a>
           </span>
           <span className='flex gap-3 sm:gap-6'>
-            <Link to='/terms-of-service' className='text-blue-600 underline'>
+            <a href='/terms' className='text-blue-600 underline'>
               이용약관
-            </Link>
-            <Link to='/privacy-policy' className='text-blue-600 underline'>
+            </a>
+            <a href='/privacy' className='text-blue-600 underline'>
               개인정보처리방침
-            </Link>
+            </a>
           </span>
         </div>
-
-        <div className='mt-4 text-xs text-gray-400'>© 2025 BookJob. All rights reserved.</div>
+        <div className='mt-4 text-xs text-dark-gray'>© 2025 BookJob. All rights reserved.</div>
       </div>
     </footer>
   )

--- a/src/components/web/Footer.jsx
+++ b/src/components/web/Footer.jsx
@@ -16,10 +16,10 @@ const Footer = ({ email, onClick }) => {
         <div className='max-w-7xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-3 sm:gap-0'>
           <nav className='flex items-center gap-3 text-sm text-dark-gray select-none'>
             <span className='font-semibold cursor-default'>북잡 </span>
-            <Link to='/privacy-policy' className='text-dark-gray underline'>
+            <Link to={ROUTER_PATHS.PRIVACY_POLICY} className='text-dark-gray underline'>
               개인정보처리방침
             </Link>
-            <Link to='/terms-of-service' className='text-dark-gray underline'>
+            <Link to={ROUTER_PATHS.TERMS_OF_SERVICE} className='text-dark-gray underline'>
               이용약관
             </Link>
           </nav>
@@ -87,10 +87,10 @@ const Footer = ({ email, onClick }) => {
             </a>
           </span>
           <span className='flex gap-3 sm:gap-6'>
-            <Link to='/privacy-policy' className='text-dark-gray underline'>
+            <Link to={ROUTER_PATHS.PRIVACY_POLICY} className='text-dark-gray underline'>
               개인정보처리방침
             </Link>
-            <Link to='/terms-of-service' className='text-dark-gray underline'>
+            <Link to={ROUTER_PATHS.TERMS_OF_SERVICE} className='text-dark-gray underline'>
               이용약관
             </Link>
           </span>

--- a/src/components/web/Footer.jsx
+++ b/src/components/web/Footer.jsx
@@ -87,12 +87,12 @@ const Footer = ({ email, onClick }) => {
             </a>
           </span>
           <span className='flex gap-3 sm:gap-6'>
-            <a href='/terms' className='text-blue-600 underline'>
+            <Link to='/terms-of-service' className='text-blue-600 underline'>
               이용약관
-            </a>
-            <a href='/privacy' className='text-blue-600 underline'>
+            </Link>
+            <Link to='/privacy-policy' className='text-blue-600 underline'>
               개인정보처리방침
-            </a>
+            </Link>
           </span>
         </div>
         <div className='mt-4 text-xs text-dark-gray'>© 2025 BookJob. All rights reserved.</div>

--- a/src/domains/job/recruitment/components/form/ClosingDate.jsx
+++ b/src/domains/job/recruitment/components/form/ClosingDate.jsx
@@ -33,6 +33,7 @@ const ClosingDate = ({ control }) => {
                 appearance: 'none',
                 textAlign: 'left',
                 paddingLeft: '16px',
+                textIndent: 0,
               }}
               min={minDate}
               value={dateValue}
@@ -42,7 +43,9 @@ const ClosingDate = ({ control }) => {
           )
         }}
       />
-      <p className='flex text-red-500 text-[13px] mt-1'>미선택시 상시채용으로 자동 입력됩니다.</p>
+      <p id='closingDateHelp' className='text-red-500 text-[13px] mt-1'>
+        미선택시 상시채용으로 자동 입력됩니다.
+      </p>
     </FormItem>
   )
 }

--- a/src/domains/main/main/MainPage.jsx
+++ b/src/domains/main/main/MainPage.jsx
@@ -45,23 +45,10 @@ const MainPage = () => {
         url='https://book-job.co.kr'
       />
 
-      <div
-        aria-hidden='true'
-        style={{
-          position: 'absolute',
-          width: '1px',
-          height: '1px',
-          padding: 0,
-          margin: '-1px',
-          overflow: 'hidden',
-          clip: 'rect(0,0,0,0)',
-          whiteSpace: 'nowrap',
-          border: 0,
-        }}
-      >
+      <p className='sr-only'>
         북잡은 출판사 채용 공고, 프리랜서 편집자·디자이너 구직 정보 등 출판 업계를 위한 구인·구직
         플랫폼입니다. 출판인들을 위한 자유게시판도 함께 운영하고 있어요.
-      </div>
+      </p>
 
       <a href={CUSTOMER_INQUIRY} target='_blank' rel='noopener noreferrer' className='w-full'>
         <BannerExample className='w-full h-full' />

--- a/src/domains/main/main/MainPage.jsx
+++ b/src/domains/main/main/MainPage.jsx
@@ -45,16 +45,22 @@ const MainPage = () => {
         url='https://book-job.co.kr'
       />
 
-      <div className='w-full px-4 sm:px-10 mt-8'>
-        <div className='max-w-3xl mx-auto text-left'>
-          <h1 className='text-2xl sm:text-3xl font-bold mb-4'>출판업계 구인구직 플랫폼, 북잡</h1>
-          <p className='text-base sm:text-lg text-gray-700 leading-relaxed'>
-            북잡은 출판사 채용 공고, 프리랜서 편집자·디자이너 구직 정보 등{' '}
-            <strong>출판 업계</strong>를 위한
-            <strong> 구인·구직 플랫폼</strong>입니다. 출판인들을 위한 자유게시판도 함께 운영하고
-            있어요.
-          </p>
-        </div>
+      <div
+        aria-hidden='true'
+        style={{
+          position: 'absolute',
+          width: '1px',
+          height: '1px',
+          padding: 0,
+          margin: '-1px',
+          overflow: 'hidden',
+          clip: 'rect(0,0,0,0)',
+          whiteSpace: 'nowrap',
+          border: 0,
+        }}
+      >
+        북잡은 출판사 채용 공고, 프리랜서 편집자·디자이너 구직 정보 등 출판 업계를 위한 구인·구직
+        플랫폼입니다. 출판인들을 위한 자유게시판도 함께 운영하고 있어요.
       </div>
 
       <a href={CUSTOMER_INQUIRY} target='_blank' rel='noopener noreferrer' className='w-full'>

--- a/src/domains/main/main/MainPage.jsx
+++ b/src/domains/main/main/MainPage.jsx
@@ -44,6 +44,19 @@ const MainPage = () => {
         image='https://book-job.co.kr/metatag.png'
         url='https://book-job.co.kr'
       />
+
+      <div className='w-full px-4 sm:px-10 mt-8'>
+        <div className='max-w-3xl mx-auto text-left'>
+          <h1 className='text-2xl sm:text-3xl font-bold mb-4'>출판업계 구인구직 플랫폼, 북잡</h1>
+          <p className='text-base sm:text-lg text-gray-700 leading-relaxed'>
+            북잡은 출판사 채용 공고, 프리랜서 편집자·디자이너 구직 정보 등{' '}
+            <strong>출판 업계</strong>를 위한
+            <strong> 구인·구직 플랫폼</strong>입니다. 출판인들을 위한 자유게시판도 함께 운영하고
+            있어요.
+          </p>
+        </div>
+      </div>
+
       <a href={CUSTOMER_INQUIRY} target='_blank' rel='noopener noreferrer' className='w-full'>
         <BannerExample className='w-full h-full' />
       </a>

--- a/src/domains/policy/page/PrivacyPolicy.jsx
+++ b/src/domains/policy/page/PrivacyPolicy.jsx
@@ -1,0 +1,121 @@
+import React from 'react'
+
+const PrivacyPolicy = () => {
+  return (
+    <section className='flex flex-col w-full max-w-[940px] mx-auto'>
+      <h1 className='text-3xl sm:text-4xl font-bold mb-10 text-left'>개인정보처리방침</h1>
+
+      <div className='space-y-10 text-base sm:text-[17px] leading-relaxed text-left'>
+        <div>
+          <p>
+            북잡(BookJob)은 이용자의 개인정보 보호를 매우 중요하게 생각하며, 「개인정보 보호법」을
+            준수합니다. 본 개인정보처리방침은 북잡이 제공하는 서비스 이용 시 수집하는 개인정보, 수집
+            목적 및 이용, 보관 기간 등을 안내합니다.
+          </p>
+        </div>
+
+        <div>
+          <h2 className='text-xl font-semibold mb-2 border-l-4 border-main-pink pl-3'>
+            1. 수집하는 개인정보 항목
+          </h2>
+          <p>회사는 다음의 개인정보를 수집할 수 있습니다:</p>
+          <ul className='list-disc pl-6 space-y-1 mt-2'>
+            <li>소셜 로그인 시 제공되는 식별자 정보 (이메일, 이름, 프로필 이미지 등)</li>
+            <li>커뮤니티 활동 시 작성한 게시글, 댓글 등의 내용</li>
+            <li>서비스 이용 기록, 접속 로그, 쿠키, IP 주소</li>
+          </ul>
+        </div>
+
+        <div>
+          <h2 className='text-xl font-semibold mb-2 border-l-4 border-main-pink pl-3'>
+            2. 개인정보 수집 방법
+          </h2>
+          <p>
+            회사는 이용자가 네이버 또는 카카오 소셜 로그인을 통해 서비스를 이용할 때 개인정보를
+            수집하며, 서비스 이용 중 자발적으로 입력한 정보 또한 수집됩니다.
+          </p>
+        </div>
+
+        <div>
+          <h2 className='text-xl font-semibold mb-2 border-l-4 border-main-pink pl-3'>
+            3. 개인정보 이용 목적
+          </h2>
+          <ul className='list-disc pl-6 space-y-1'>
+            <li>회원 식별 및 서비스 이용을 위한 인증</li>
+            <li>게시글/댓글 작성 등 커뮤니티 기능 제공</li>
+            <li>서비스 개선, 오류 분석 및 고객 응대</li>
+            <li>법령에 따른 의무 이행</li>
+          </ul>
+        </div>
+
+        <div>
+          <h2 className='text-xl font-semibold mb-2 border-l-4 border-main-pink pl-3'>
+            4. 개인정보 보유 및 이용기간
+          </h2>
+          <p>
+            회원 탈퇴 시 수집된 개인정보는 지체 없이 파기합니다. 단, 관련 법령에 따라 일정 기간
+            보존이 필요한 경우 해당 기간 동안 보관 후 파기합니다.
+          </p>
+        </div>
+
+        <div>
+          <h2 className='text-xl font-semibold mb-2 border-l-4 border-main-pink pl-3'>
+            5. 개인정보 제3자 제공
+          </h2>
+          <p>
+            회사는 이용자의 동의 없이 개인정보를 제3자에게 제공하지 않습니다. 단, 법령에 따라 요청이
+            있는 경우에만 예외적으로 제공될 수 있습니다.
+          </p>
+        </div>
+
+        <div>
+          <h2 className='text-xl font-semibold mb-2 border-l-4 border-main-pink pl-3'>
+            6. 개인정보 처리 위탁
+          </h2>
+          <p>
+            회사는 원활한 서비스 제공을 위해 일부 업무를 외부에 위탁할 수 있으며, 위탁 시 개인정보가
+            안전하게 처리되도록 관리합니다.
+          </p>
+        </div>
+
+        <div>
+          <h2 className='text-xl font-semibold mb-2 border-l-4 border-main-pink pl-3'>
+            7. 이용자의 권리와 행사 방법
+          </h2>
+          <ul className='list-disc pl-6 space-y-1'>
+            <li>이용자는 언제든지 자신의 개인정보를 열람, 수정, 삭제할 수 있습니다.</li>
+            <li>탈퇴 후에도 게시글/댓글 등 콘텐츠는 삭제되지 않으며, 사전 삭제가 필요합니다.</li>
+            <li>요청은 이메일을 통해 접수받으며, 지체 없이 조치합니다.</li>
+          </ul>
+        </div>
+
+        <div>
+          <h2 className='text-xl font-semibold mb-2 border-l-4 border-main-pink pl-3'>
+            8. 쿠키(Cookie)의 사용
+          </h2>
+          <p>
+            북잡은 서비스 품질 향상과 분석을 위해 쿠키를 사용할 수 있습니다. 사용자는 브라우저
+            설정을 통해 쿠키 저장을 거부할 수 있습니다.
+          </p>
+        </div>
+
+        <div>
+          <h2 className='text-xl font-semibold mb-2 border-l-4 border-main-pink pl-3'>
+            9. 개인정보 보호 책임자
+          </h2>
+          <p>
+            개인정보 관련 문의사항은 아래 이메일로 문의해 주시기 바랍니다. 회사는 신속하고 성실하게
+            답변하겠습니다.
+          </p>
+          <p className='mt-2'>• 이메일: bookjob.help@gmail.com</p>
+        </div>
+
+        <p className='text-sm text-gray-500 pt-6 border-t mt-10'>
+          본 개인정보처리방침은 2025년 7월 3일부터 시행됩니다.
+        </p>
+      </div>
+    </section>
+  )
+}
+
+export default PrivacyPolicy

--- a/src/domains/policy/page/TermsOfService.jsx
+++ b/src/domains/policy/page/TermsOfService.jsx
@@ -1,0 +1,143 @@
+import React from 'react'
+
+const TermsOfService = () => {
+  return (
+    <section className='flex flex-col w-full max-w-[940px] mx-auto'>
+      <h1 className='text-3xl sm:text-4xl font-bold mb-10 text-left'>북잡 이용약관</h1>
+
+      <div className='space-y-10 text-base sm:text-[17px] leading-relaxed text-left'>
+        <div>
+          <p>
+            본 약관은 북잡(BookJob) 웹사이트(이하 "회사" 또는 "북잡")가 제공하는 모든 서비스의
+            이용과 관련하여 회원과 회사 간의 권리, 의무 및 책임사항을 규정함을 목적으로 합니다.
+          </p>
+        </div>
+
+        <div>
+          <h2 className='text-xl font-semibold mb-2 border-l-4 border-main-pink pl-3'>
+            제1조 (목적)
+          </h2>
+          <p>
+            이 약관은 회사가 제공하는 온라인 구인·구직 서비스 및 커뮤니티 기능 이용에 대한 조건과
+            절차, 이용자와 회사의 권리·의무를 규정합니다.
+          </p>
+        </div>
+
+        <div>
+          <h2 className='text-xl font-semibold mb-2 border-l-4 border-main-pink pl-3'>
+            제2조 (정의)
+          </h2>
+          <ul className='list-disc pl-6 space-y-1'>
+            <li>
+              “서비스”란 북잡 웹사이트 및 모바일 웹 등 회사가 제공하는 기능 일체를 의미합니다.
+            </li>
+            <li>“회원”이란 회사와 이용계약을 체결하고 서비스를 이용하는 자를 말합니다.</li>
+            <li>“게시물”이란 회원이 서비스에 작성·등록한 글, 댓글, 이미지 등을 말합니다.</li>
+          </ul>
+        </div>
+
+        <div>
+          <h2 className='text-xl font-semibold mb-2 border-l-4 border-main-pink pl-3'>
+            제3조 (약관의 효력 및 변경)
+          </h2>
+          <p>
+            이 약관은 서비스 화면에 게시하거나 기타 방법으로 공지함으로써 효력이 발생하며, 회사는
+            관련 법령을 위반하지 않는 범위에서 약관을 변경할 수 있습니다.
+          </p>
+        </div>
+
+        <div>
+          <h2 className='text-xl font-semibold mb-2 border-l-4 border-main-pink pl-3'>
+            제4조 (회원가입)
+          </h2>
+          <p>
+            회원은 네이버 또는 카카오 소셜 로그인을 통해 가입할 수 있으며, 회사는 허위 정보 또는
+            부정 사용이 확인될 경우 가입을 제한할 수 있습니다.
+          </p>
+        </div>
+
+        <div>
+          <h2 className='text-xl font-semibold mb-2 border-l-4 border-main-pink pl-3'>
+            제5조 (회원의 의무)
+          </h2>
+          <ul className='list-disc pl-6 space-y-1'>
+            <li>타인의 정보를 도용하거나 허위 정보를 입력해서는 안 됩니다.</li>
+            <li>타인을 비방하거나 명예를 훼손하는 게시물을 작성해서는 안 됩니다.</li>
+            <li>서비스를 상업적 목적으로 이용하거나 광고성 정보를 무단 게시해서는 안 됩니다.</li>
+          </ul>
+        </div>
+
+        <div>
+          <h2 className='text-xl font-semibold mb-2 border-l-4 border-main-pink pl-3'>
+            제6조 (서비스의 제공 및 변경)
+          </h2>
+          <p>
+            회사는 서비스의 전부 또는 일부를 변경하거나 중단할 수 있으며, 이에 대해 별도의 보상을
+            하지 않습니다.
+          </p>
+        </div>
+
+        <div>
+          <h2 className='text-xl font-semibold mb-2 border-l-4 border-main-pink pl-3'>
+            제7조 (게시물의 관리)
+          </h2>
+          <p>
+            회원이 작성한 게시물의 책임은 작성자에게 있으며, 회사는 다음과 같은 경우 게시물을
+            삭제하거나 숨길 수 있습니다:
+          </p>
+          <ul className='list-disc pl-6 space-y-1 mt-2'>
+            <li>불법적이거나 타인의 권리를 침해하는 경우</li>
+            <li>욕설, 음란물, 혐오 표현이 포함된 경우</li>
+            <li>도배, 광고, 홍보성 게시물인 경우</li>
+          </ul>
+        </div>
+
+        <div>
+          <h2 className='text-xl font-semibold mb-2 border-l-4 border-main-pink pl-3'>
+            제8조 (구인·구직 관련 면책)
+          </h2>
+          <p>
+            북잡은 구인·구직 게시물의 진위 여부를 보증하지 않으며, 회원 간 거래 또는 채용 관련
+            분쟁에 개입하지 않습니다.
+          </p>
+        </div>
+
+        <div>
+          <h2 className='text-xl font-semibold mb-2 border-l-4 border-main-pink pl-3'>
+            제9조 (계정 탈퇴 및 삭제)
+          </h2>
+          <p>
+            회원은 언제든지 서비스 내에서 탈퇴할 수 있으며, 탈퇴 시 계정 정보는 삭제됩니다. 단,
+            게시물은 삭제되지 않으며 원할 경우 탈퇴 전 삭제해야 합니다.
+          </p>
+        </div>
+
+        <div>
+          <h2 className='text-xl font-semibold mb-2 border-l-4 border-main-pink pl-3'>
+            제10조 (면책조항)
+          </h2>
+          <p>
+            회사는 천재지변, 시스템 장애 등 불가항력적인 사유로 인해 발생한 손해에 대해 책임을 지지
+            않습니다.
+          </p>
+        </div>
+
+        <div>
+          <h2 className='text-xl font-semibold mb-2 border-l-4 border-main-pink pl-3'>
+            제11조 (관할법원 및 준거법)
+          </h2>
+          <p>
+            이 약관은 대한민국 법령에 따라 해석되며, 분쟁 발생 시 회사 소재지의 관할 법원을 제1심
+            전속관할 법원으로 합니다.
+          </p>
+        </div>
+
+        <p className='text-sm text-gray-500 pt-6 border-t mt-10'>
+          부칙: 본 약관은 2025년 7월 3일부터 시행합니다.
+        </p>
+      </div>
+    </section>
+  )
+}
+
+export default TermsOfService

--- a/src/routes/RouterPath.js
+++ b/src/routes/RouterPath.js
@@ -32,6 +32,8 @@ const ROUTER_PATHS = {
   ERROR: '/error',
   KAKAO_SUCCESS: '/login/kakao/success',
   NAVER_SUCCESS: '/login/naver/success',
+  TERMS_OF_SERVICE: '/terms-of-service',
+  PRIVACY_POLICY: '/privacy-policy',
 }
 
 export default ROUTER_PATHS

--- a/src/routes/routes.jsx
+++ b/src/routes/routes.jsx
@@ -30,6 +30,8 @@ import EditJobSeekPostPage from '../domains/job/search/edit/page/EditJobSeekPost
 import KakaoSuccess from '../domains/login/page/KakaoSuccess'
 import NaverSuccess from '../domains/login/page/NaverSuccess'
 import MyRecentList from '../domains/my/detail/MyRecentList'
+import TermsOfService from '../domains/policy/page/TermsOfService'
+import PrivacyPolicy from '../domains/policy/page/PrivacyPolicy'
 
 const routes = [
   {
@@ -195,6 +197,14 @@ const routes = [
   {
     path: ROUTER_PATHS.NAVER_SUCCESS,
     element: <NaverSuccess />,
+  },
+  {
+    path: ROUTER_PATHS.TERMS_OF_SERVICE,
+    element: <TermsOfService />,
+  },
+  {
+    path: ROUTER_PATHS.PRIVACY_POLICY,
+    element: <PrivacyPolicy />,
   },
 ]
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#226 

### 📝작업 내용

- [x] 1. 이용약관 & 개인정보 연결하기
- [x]  2. 구인 마감 인풋박스 가운데 
- [x]  3. 구글 검색 했을 때 아이콘 수정하기
- [x]  4. meta-tag 수정
- [x]  5. footer 수정

### 📸 스크린샷 (선택)

### 💬리뷰 요구사항(선택)

리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **신규 기능**
  * 서비스 이용약관 및 개인정보처리방침 페이지가 추가되었습니다.
  * 푸터에서 약관 및 개인정보처리방침으로 바로 이동할 수 있는 링크가 제공됩니다.

* **버그 수정**
  * 날짜 입력란의 접근성이 개선되었습니다.

* **접근성**
  * 메인 페이지에 스크린 리더 전용 설명이 추가되어 시각장애인 이용자의 접근성이 향상되었습니다.
  * 푸터의 회사 정보가 모바일에서 접이식으로 제공되고, 키보드 및 스크린 리더 접근성이 강화되었습니다.

* **기타**
  * Open Graph 및 Twitter 메타 태그의 이미지와 URL이 절대 경로로 수정되어 소셜 미디어 공유 시 올바른 정보가 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->