### PR TITLE
[publishing-27/style] 502 페이지 생성

### DIFF
--- a/src/domains/error/page/ErrorPage.jsx
+++ b/src/domains/error/page/ErrorPage.jsx
@@ -6,11 +6,11 @@ const ErrorPage = () => {
 
   return (
     <section className='flex flex-col items-center justify-center text-center px-4'>
-      <h1 className='text-2xl font-bold mb-4'>404 - 페이지를 찾을 수 없습니다 😢</h1>
+      <h1 className='text-2xl font-bold mb-4'>페이지를 찾을 수 없습니다 😢</h1>
       <p className='text-dark-gray mb-8'>주소가 잘못되었거나, 존재하지 않는 페이지입니다.</p>
       <button
         onClick={() => navigate(ROUTER_PATHS.MAIN_PAGE)}
-        className='px-6 py-2 bg-main-pink text-white rounded-lg hover:bg-pink-500 transition-colors'
+        className='px-6 py-2 bg-main-pink text-white rounded-lg hover:bg-hover-pink transition-colors'
         aria-label='홈으로 이동하기'
       >
         홈으로 이동

--- a/src/domains/error/page/ServerErrorPage.jsx
+++ b/src/domains/error/page/ServerErrorPage.jsx
@@ -1,0 +1,21 @@
+import { useNavigate } from 'react-router-dom'
+import ROUTER_PATHS from '../../../routes/RouterPath'
+
+const ServerErrorPage = () => {
+  const navigate = useNavigate()
+
+  return (
+    <section className='flex flex-col items-center justify-center text-center px-4'>
+      <h1 className='text-2xl font-bold mb-4'>서버 점검 중입니다 🔧</h1>
+      <p className='text-dark-gray mb-8'>잠시 후 다시 시도해주세요.</p>
+      <button
+        onClick={() => navigate(ROUTER_PATHS.MAIN_PAGE)}
+        className='px-6 py-2 bg-main-pink text-white rounded-lg hover:bg-hover-pink transition-colors'
+        aria-label='홈으로 이동하기'
+      >
+        홈으로 이동
+      </button>
+    </section>
+  )
+}
+export default ServerErrorPage

--- a/src/routes/RouterPath.js
+++ b/src/routes/RouterPath.js
@@ -30,6 +30,7 @@ const ROUTER_PATHS = {
   MY_RECENT_LIST: '/my-page/my-recent-list',
   MY_DRAFTS: '/my-page/my-drafts',
   ERROR: '/error',
+  SERVER_ERROR: '/server-error',
   KAKAO_SUCCESS: '/login/kakao/success',
   NAVER_SUCCESS: '/login/naver/success',
   TERMS_OF_SERVICE: '/terms-of-service',

--- a/src/routes/routes.jsx
+++ b/src/routes/routes.jsx
@@ -33,6 +33,8 @@ import MyRecentList from '../domains/my/detail/MyRecentList'
 import TermsOfService from '../domains/policy/page/TermsOfService'
 import PrivacyPolicy from '../domains/policy/page/PrivacyPolicy'
 import InstallMethod from '../domains/policy/page/InstallMethod'
+import { element } from 'prop-types'
+import ServerErrorPage from '../domains/error/page/ServerErrorPage'
 
 const routes = [
   {
@@ -191,6 +193,10 @@ const routes = [
   {
     path: '*',
     element: <ErrorPage />,
+  },
+  {
+    path: ROUTER_PATHS.SERVER_ERROR,
+    element: <ServerErrorPage />,
   },
   {
     path: ROUTER_PATHS.KAKAO_SUCCESS,

--- a/src/routes/routes.jsx
+++ b/src/routes/routes.jsx
@@ -33,7 +33,6 @@ import MyRecentList from '../domains/my/detail/MyRecentList'
 import TermsOfService from '../domains/policy/page/TermsOfService'
 import PrivacyPolicy from '../domains/policy/page/PrivacyPolicy'
 import InstallMethod from '../domains/policy/page/InstallMethod'
-import { element } from 'prop-types'
 import ServerErrorPage from '../domains/error/page/ServerErrorPage'
 
 const routes = [


### PR DESCRIPTION
## #️⃣연관된 이슈

#297 

### 📝작업 내용

- [x] 502 에러 페이지 생성했습니다 ~

### 📸 스크린샷 (선택)

<img width="1440" height="812" alt="스크린샷 2025-08-25 오후 10 32 21" src="https://github.com/user-attachments/assets/93925d49-1087-4bd3-9c2b-b33bd956fec0" />

### 💬리뷰 요구사항(선택)
404 페이지랑 ui 똑같이 했어요! 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 새 기능
  - 서버 점검 안내 페이지를 추가해 점검 시 사용자에게 명확한 안내와 "홈으로 이동" 버튼을 제공합니다.
  - 서버 점검 전용 경로를 라우팅에 추가해 직접 접근 및 안내 페이지로의 이동이 가능합니다.

- 스타일
  - 에러 페이지 제목에서 “404 - ” 접두사를 제거해 문구를 간결화했습니다.
  - 버튼 호버 색상을 일관된 디자인 토큰(hover:bg-hover-pink)으로 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->