### PR TITLE
[bug-32/fix] 이메일 인증 오류메세지 변경 / 작성글 제목 길이 50자로 변경

### DIFF
--- a/src/hooks/writePost/useTitleValidation.js
+++ b/src/hooks/writePost/useTitleValidation.js
@@ -1,6 +1,6 @@
 import { useForm } from 'react-hook-form'
 
-export const MAX_TITLE_LENGTH = 30
+export const MAX_TITLE_LENGTH = 50
 
 export default function useTitleValidation() {
   return {


### PR DESCRIPTION
## #️⃣연관된 이슈

#301 

### 📝작업 내용

- [ ] 이메일 인증 오류메세지 변경
- [ ] 작성글 제목 길이 50자로 변경

### 📸 스크린샷 (선택)

