### PR TITLE
[publishing-31/style] 구인구직 최신글 (오늘의 구인구직)

### DIFF
--- a/src/domains/main/common/components/BestList.jsx
+++ b/src/domains/main/common/components/BestList.jsx
@@ -22,7 +22,9 @@ const BestList = ({ boardName, bestList }) => {
           />
           Your browser does not support the video tag.
         </video>
-        <div className='text-xl font-bold sm:text-3xl'>{boardName} 베스트</div>
+        <div className='text-xl font-bold sm:text-3xl'>
+          {boardName} {boardName === '최신글' ? null : '베스트'}
+        </div>
       </div>
       {bestList.length !== 0 ? (
         <div className='grid grid-cols-1 sm:grid-cols-2 gap-y-4 sm:gap-x-20 sm:grid-flow-col sm:grid-rows-5'>

--- a/src/domains/main/common/components/BoardButton.jsx
+++ b/src/domains/main/common/components/BoardButton.jsx
@@ -1,21 +1,18 @@
-import { useNavigate } from 'react-router-dom'
 import commonTime from '../../../../assets/icons/common/common_time.svg'
 
 const BoardButton = ({ onBoardSelect, selectedBoard, handleRefresh }) => {
   const boardButton = [{ name: '구인구직' }, { name: '자유' }, { name: '최신글' }]
-  const navigate = useNavigate()
   const today = new Date()
   const formattedDate = `${today.getMonth() + 1}월 ${today.getDate()}일`
 
-  const handleClick = (path, name) => {
-    navigate(path)
+  const handleClick = (name) => {
     onBoardSelect(name === '자유' ? '자유게시판' : name === '구인구직' ? '구인구직' : '최신글')
   }
   return (
     <div className='flex justify-center w-full max-w-[940px] mx-auto'>
       <div className='items-end w-full'>
         <p className='flex justify-center w-full gap-3'>
-          {boardButton.map(({ name, path }, index) => {
+          {boardButton.map(({ name }, index) => {
             const isSelected =
               (name === '자유' && selectedBoard === '자유게시판') ||
               (name === '구인구직' && selectedBoard === '구인구직') ||
@@ -23,7 +20,7 @@ const BoardButton = ({ onBoardSelect, selectedBoard, handleRefresh }) => {
             return (
               <button
                 key={index}
-                onClick={() => handleClick(path, name)}
+                onClick={() => handleClick(name)}
                 className={`sm:w-[157px] w-[100px] sm:h-[47px] h-[32px]  rounded-full sm:text-2xl  text-lg font-bold ${
                   isSelected ? 'bg-main-pink text-white' : 'text-black'
                 }`}

--- a/src/domains/main/common/components/BoardButton.jsx
+++ b/src/domains/main/common/components/BoardButton.jsx
@@ -2,14 +2,14 @@ import { useNavigate } from 'react-router-dom'
 import commonTime from '../../../../assets/icons/common/common_time.svg'
 
 const BoardButton = ({ onBoardSelect, selectedBoard, handleRefresh }) => {
-  const boardButton = [{ name: '자유' }, { name: '구인구직' }]
+  const boardButton = [{ name: '구인구직' }, { name: '자유' }, { name: '최신글' }]
   const navigate = useNavigate()
   const today = new Date()
   const formattedDate = `${today.getMonth() + 1}월 ${today.getDate()}일`
 
   const handleClick = (path, name) => {
     navigate(path)
-    onBoardSelect(name === '자유' ? '자유게시판' : '구인구직')
+    onBoardSelect(name === '자유' ? '자유게시판' : name === '구인구직' ? '구인구직' : '최신글')
   }
   return (
     <div className='flex justify-center w-full max-w-[940px] mx-auto'>
@@ -18,7 +18,8 @@ const BoardButton = ({ onBoardSelect, selectedBoard, handleRefresh }) => {
           {boardButton.map(({ name, path }, index) => {
             const isSelected =
               (name === '자유' && selectedBoard === '자유게시판') ||
-              (name === '구인구직' && selectedBoard === '구인구직')
+              (name === '구인구직' && selectedBoard === '구인구직') ||
+              (name === '최신글' && selectedBoard === '최신글')
             return (
               <button
                 key={index}

--- a/src/domains/main/main/MainPage.jsx
+++ b/src/domains/main/main/MainPage.jsx
@@ -34,9 +34,9 @@ const MainPage = () => {
     Promise.all([fetchFreeBest(), fetchJobBest()])
   }, [fetchFreeBest, fetchJobBest])
 
-  const currentList = selectedBoard === '자유게시판' ? freeBest : jobBest
-  const isLoading = selectedBoard === '자유게시판' ? isFreeLoading : isJobLoading
-  const error = selectedBoard === '자유게시판' ? freeError : jobError
+  const currentList = selectedBoard === '자유게시판' ? freeBest : selectedBoard === '구인구직' ? jobBest : freeBest
+  const isLoading = selectedBoard === '자유게시판' ? isFreeLoading : selectedBoard === '구인구직' ? isJobLoading : isFreeLoading
+  const error = selectedBoard === '자유게시판' ? freeError : selectedBoard === '구인구직' ? jobError : freeError
 
   return (
     <>

--- a/src/domains/main/main/MainPage.jsx
+++ b/src/domains/main/main/MainPage.jsx
@@ -5,8 +5,6 @@ import useBestStore from '../../../store/main/useBestStore'
 import Spinner from '../../../components/web/Spinner'
 import Banner from '../../../components/common/Banner'
 import SeoHelmet from '../../../components/common/SeoHelmet'
-// import SurveyModal from '../common/components/Modals/SurveyModal'
-// import CoffeeEvent from '../common/components/Modals/CoffeeEvent'
 const MainPage = () => {
   const [selectedBoard, setSelectedBoard] = useState('구인구직')
 
@@ -81,8 +79,6 @@ const MainPage = () => {
           )}
         </div>
       </div>
-      {/* <SurveyModal /> */}
-      {/* <CoffeeEvent /> */}
     </>
   )
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#328 

### 📝작업 내용

- [x] 최신글 버튼 추가

### 📸 스크린샷 (선택)
<img width="1189" height="466" alt="image" src="https://github.com/user-attachments/assets/bad4a495-81f2-4e34-937b-5ab503f0f566" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 보드 선택에 ‘최신글’을 추가하고 버튼 순서를 [구인구직, 자유, 최신글]로 재정렬했습니다.
  * 보드 선택 동작을 경로 이동이 아닌 보드 식별자 업데이트 방식으로 변경하여 선택 상태(하이라이트)가 정확히 반영됩니다.
  * 메인 화면에서 ‘구인구직’ 보드의 콘텐츠·로딩·오류 상태를 명확히 반영하도록 처리했습니다.
  * 베스트 목록 헤더는 ‘최신글’일 때 접미사 ‘베스트’를 생략하도록 변경했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->