### PR TITLE
[bug-38/fix] 이메일 인증 재전송/ 팝업 수정/ 메인 베스트 아이콘 위치 수정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, useLocation } from 'react-router-dom'
+import { BrowserRouter } from 'react-router-dom'
 import AppRoutes from './routes/AppRoutes'
 import PageScrollToTop from './components/common/PageScrollToTop'
 import { useEffect } from 'react'

--- a/src/domains/Find/common/components/OTPInput.jsx
+++ b/src/domains/Find/common/components/OTPInput.jsx
@@ -1,37 +1,13 @@
 import { useEffect, useState } from 'react'
 import ToastService from '../../../../services/toast/ToastService'
 import Button from '../../../../components/web/Button'
+import PropTypes from 'prop-types'
 
-const OTPInput = ({ size, placeholder, startTimer, onVerify }) => {
+const OTPInput = ({ placeholder, startTimer, timeLeft, onVerify }) => {
   const [code, setCode] = useState('')
-  const [timeLeft, setTimeLeft] = useState(300)
-  const [isExpired, setIsExpired] = useState(true)
 
-  useEffect(() => {
-    if (!startTimer || isExpired) {
-      return
-    }
-    if (timeLeft <= 0) {
-      setIsExpired(true)
-      return
-    }
+  const isExpired = !startTimer || timeLeft <= 0
 
-    const timer = setInterval(() => {
-      setTimeLeft((prev) => prev - 1)
-    }, 1000)
-
-    return () => clearInterval(timer)
-  }, [timeLeft, isExpired])
-
-  useEffect(() => {
-    if (!startTimer) {
-      setTimeLeft(300)
-      setIsExpired(true)
-      setCode('')
-    } else {
-      setIsExpired(false)
-    }
-  }, [startTimer])
   const formatTime = (seconds) => {
     const min = String(Math.floor(seconds / 60)).padStart(2, '0')
     const sec = String(seconds % 60).padStart(2, '0')
@@ -48,7 +24,6 @@ const OTPInput = ({ size, placeholder, startTimer, onVerify }) => {
       ToastService.info('인증번호를 입력해주세요.')
       return
     }
-
     onVerify(code)
   }
 
@@ -87,5 +62,11 @@ const OTPInput = ({ size, placeholder, startTimer, onVerify }) => {
     </div>
   )
 }
-
+OTPInput.propTypes = {
+  size: PropTypes.string,
+  placeholder: PropTypes.string,
+  startTimer: PropTypes.bool,
+  timeLeft: PropTypes.number.isRequired,
+  onVerify: PropTypes.func.isRequired,
+}
 export default OTPInput

--- a/src/domains/main/common/components/BestList.jsx
+++ b/src/domains/main/common/components/BestList.jsx
@@ -47,7 +47,7 @@ const BestList = ({ boardName, bestList }) => {
                   >
                     {title}
                   </button>
-                  <div className='flex items-center justify-between w-auto min-w-0 ml-2 shrink-0'>
+                  <div className='flex items-center justify-between w-auto ml-2 shrink-0'>
                     {boardId ? (
                       <>
                         <img
@@ -55,13 +55,13 @@ const BestList = ({ boardName, bestList }) => {
                           alt='comment'
                           className='sm:w-[19px] w-[15px] h-[13px] sm:h-[17px] mr-2'
                         />
-                        {commentCount}
+                        <span className='w-auto sm:min-w-10 min-w-8'>{commentCount}</span>
                         <img
                           src={viewGray}
                           alt='comment'
                           className='sm:w-[19px] w-[15px] h-[13px] sm:h-[17px] mx-2'
                         />
-                        {viewCount}
+                        <span className='w-auto sm:min-w-10 min-w-8'>{viewCount}</span>
                       </>
                     ) : (
                       <>
@@ -70,7 +70,7 @@ const BestList = ({ boardName, bestList }) => {
                           alt='viewCount'
                           className='sm:w-[19px] w-[15px] h-[13px] sm:h-[17px] mr-2'
                         />
-                        {viewCount}
+                        <span className='w-auto sm:min-w-10 min-w-8'>{viewCount}</span>
                       </>
                     )}
                   </div>

--- a/src/domains/main/common/components/Modals/EventModal.jsx
+++ b/src/domains/main/common/components/Modals/EventModal.jsx
@@ -21,7 +21,7 @@ export default function EventModal({
     <div className='fixed inset-0 z-50 flex items-center justify-center bg-black/50'>
       <div className='relative w-[90%] max-w-md'>
         {link ? (
-          <a href={link} target='_blank' rel='noopener noreferrer'>
+          <a href={link} target='_blank' onClick={() => onClose()} rel='noopener noreferrer'>
             <img
               src={isMobile && mobileImage ? mobileImage : image}
               alt={alt}

--- a/src/domains/main/common/components/Modals/ModalManager.jsx
+++ b/src/domains/main/common/components/Modals/ModalManager.jsx
@@ -48,11 +48,15 @@ export default function ModalManager() {
     handleClose()
   }
   const handleModalClick = (modalConfig) => {
-    if (modalConfig.onClick) {
-      modalConfig.onClick({ setShowModal })() 
-      handleClose()
-      setModalQueue([])
+    if (!modalConfig?.onClick) return
+
+    const handler = modalConfig.onClick({ setShowModal })
+    if (typeof handler === 'function') {
+      handler()
     }
+
+    handleClose()
+    setModalQueue([])
   }
 
   return (

--- a/src/domains/main/common/components/Modals/ModalManager.jsx
+++ b/src/domains/main/common/components/Modals/ModalManager.jsx
@@ -3,8 +3,7 @@ import PropTypes from 'prop-types'
 import EventModal from './EventModal'
 import useAuthStore from '../../../../../store/login/useAuthStore'
 import useWriteModalStore from '../../../../../store/modal/useWriteModalStore'
-import modalConfigs from './modalConfigs';
-
+import modalConfigs from './modalConfigs'
 
 const PROMO_LOCK_KEY = '__PROMO_MODAL_OPEN__'
 
@@ -48,6 +47,13 @@ export default function ModalManager() {
     localStorage.setItem(currentModal.doNotShowKey, today)
     handleClose()
   }
+  const handleModalClick = (modalConfig) => {
+    if (modalConfig.onClick) {
+      modalConfig.onClick({ setShowModal })() 
+      handleClose()
+      setModalQueue([])
+    }
+  }
 
   return (
     <div>
@@ -61,7 +67,7 @@ export default function ModalManager() {
           link={currentModal.link}
           alt={currentModal.alt}
           doNotShowText='오늘 하루 보지 않기'
-          onClick={currentModal.onClick ? currentModal.onClick({ setShowModal }) : undefined}
+          onClick={() => handleModalClick(currentModal)}
         />
       )}
     </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

#356 

### 📝작업 내용

- [x] 이메일 인증 재전송
- [x] 팝업 수정
- [x] 메인 베스트 아이콘 위치 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 이메일 인증에 재전송 대기(15초)와 5분 카운트다운이 추가되고, 입력 변경 시 타이머가 리셋되며 만료 안내가 표시됩니다.
  - OTP 입력이 외부에서 전달되는 남은 시간과 시작 플래그에 따라 동기화되어 만료 시 자동 비활성화됩니다.
- 버그 수정
  - 이벤트 모달의 링크 클릭 시 모달을 닫고 큐를 정리하도록 개선했습니다.
- 스타일
  - 베스트 리스트의 댓글/조회수 표시 가독성을 향상했습니다.
- 잡무
  - 사용되지 않는 라우터 의존성을 제거했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->