### PR TITLE
[bug-39/fix] 자유게시판 좋아요 내가 눌렀는지 여부 수정 완료

### DIFF
--- a/src/components/common/LikeCount.jsx
+++ b/src/components/common/LikeCount.jsx
@@ -9,7 +9,6 @@ const LikeCount = ({ id, initialCount = 0, initialActive = false, className }) =
   const [active, setActive] = useState(initialActive)
   const [loading, setLoading] = useState(false)
 
-  // props 변경 시 state 동기화
   useEffect(() => {
     setCount(initialCount)
   }, [initialCount])
@@ -26,10 +25,8 @@ const LikeCount = ({ id, initialCount = 0, initialActive = false, className }) =
       const newActive = !active
       const newCount = newActive ? count + 1 : count - 1
 
-      // 서버에 현재 상태 반영
       await toggleLike(id, newActive)
 
-      // 클릭 즉시 UI 업데이트
       setActive(newActive)
       setCount(newCount)
     } catch (error) {

--- a/src/components/common/LikeCount.jsx
+++ b/src/components/common/LikeCount.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import GoodIcon from '../../assets/icons/common/common_good.svg'
 import NotGoodIcon from '../../assets/icons/common/common_good_before_icon.svg'
@@ -9,6 +9,15 @@ const LikeCount = ({ id, initialCount = 0, initialActive = false, className }) =
   const [active, setActive] = useState(initialActive)
   const [loading, setLoading] = useState(false)
 
+  // props 변경 시 state 동기화
+  useEffect(() => {
+    setCount(initialCount)
+  }, [initialCount])
+
+  useEffect(() => {
+    setActive(initialActive)
+  }, [initialActive])
+
   const handleClick = async () => {
     if (loading) return
     setLoading(true)
@@ -17,8 +26,10 @@ const LikeCount = ({ id, initialCount = 0, initialActive = false, className }) =
       const newActive = !active
       const newCount = newActive ? count + 1 : count - 1
 
+      // 서버에 현재 상태 반영
       await toggleLike(id, newActive)
 
+      // 클릭 즉시 UI 업데이트
       setActive(newActive)
       setCount(newCount)
     } catch (error) {

--- a/src/domains/community/detail/page/DetailCommunityPage.jsx
+++ b/src/domains/community/detail/page/DetailCommunityPage.jsx
@@ -131,7 +131,7 @@ const DetailCommunityPage = () => {
         <LikeCount
           id={id}
           initialCount={post.likeCount ?? 0}
-          initialActive={false}
+          initialActive={post.isLiked}
           className='mt-2 text-dark-gray'
         />
       )}


### PR DESCRIPTION
## #️⃣연관된 이슈

#360 

### 📝작업 내용
- [x] 사용자가 해당 게시물을 눌렀을 경우 여부를 적용해줬습니다 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 커뮤니티 게시글 상세의 좋아요 버튼이 초기 로드 시 게시글의 현재 좋아요 상태를 정확히 반영하도록 수정했습니다.
  - 좋아요 수와 활성 상태가 외부 데이터 변경(예: 새로고침 없이 상태 갱신)에도 화면에 즉시 동기화되어 표시 불일치를 해소했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->