### PR TITLE
[bug-41/fix] 최신글 바로가기 경로 수정 /MainPage 뒤로가기 복귀 기능 보강

### DIFF
--- a/src/domains/main/common/components/BestList.jsx
+++ b/src/domains/main/common/components/BestList.jsx
@@ -30,7 +30,7 @@ const BestList = ({ boardName, bestList }) => {
       </div>
       {bestList.length !== 0 ? (
         <div className='grid grid-cols-1 sm:grid-cols-2 gap-y-4 sm:gap-x-20 sm:grid-flow-col sm:grid-rows-5'>
-          {bestList.map(({ title, boardId, jobPostingId, Id, commentCount, viewCount }, index) => {
+          {bestList.map(({ title, boardId, jobPostingId, id, commentCount, viewCount }, index) => {
             return (
               <div key={index} className='flex items-center hover:scale-105'>
                 <p className='w-5 sm:text-[20px] text-[15px] font-medium'>{index + 1}.</p>
@@ -42,7 +42,9 @@ const BestList = ({ boardName, bestList }) => {
                         ? () => navigate(`/community/post/${boardId}`)
                         : jobPostingId
                           ? () => navigate(`/job/recruitment/post/${jobPostingId}`)
-                          : () => navigate(`/job/recruitment/post/${Id}`)
+                          : id
+                            ? () => navigate(`/job/recruitment/post/${id}`)
+                            : null
                     }
                   >
                     {title}

--- a/src/domains/main/main/MainPage.jsx
+++ b/src/domains/main/main/MainPage.jsx
@@ -5,8 +5,10 @@ import useBestStore from '../../../store/main/useBestStore'
 import Spinner from '../../../components/web/Spinner'
 import Banner from '../../../components/common/Banner'
 import SeoHelmet from '../../../components/common/SeoHelmet'
+import { useSearchParams } from 'react-router-dom'
 const MainPage = () => {
-  const [selectedBoard, setSelectedBoard] = useState('구인구직')
+  const [searchParams, setSearchParams] = useSearchParams()
+  const [selectedBoard, setSelectedBoard] = useState(searchParams.get('board') || '구인구직')
 
   const {
     freeBest,
@@ -25,6 +27,7 @@ const MainPage = () => {
 
   const handleBoardSelect = (boardName) => {
     setSelectedBoard(boardName)
+    setSearchParams({ board: boardName }) 
   }
 
   const handleRefresh = () => {


### PR DESCRIPTION
## #️⃣연관된 이슈

#368 

### 📝작업 내용

- [x] 최신글 바로가기 경로 수정
- [x] 메인페이지 ->상세글에서 뒤로가기시 보던 페이지로 복귀기능 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 메인 페이지 보드 선택 상태를 URL 쿼리 파라미터(board=)와 동기화합니다. 초기 진입 시 파라미터를 반영하고, 탭 전환 시 주소가 업데이트되어 딥링크 및 공유가 용이해졌습니다.
* 버그 수정
  * BestList 항목 식별자 대소문자 불일치(Id→id)로 인한 탐색 폴백 경로 문제를 수정했습니다. id/boardId/jobPostingId가 없을 때 안전하게 처리하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->