### PR TITLE
[publishing-34/style] 구인 & 구직 탭 디자인 수정 완료

### DIFF
--- a/src/domains/job/main/components/JobDropDown.jsx
+++ b/src/domains/job/main/components/JobDropDown.jsx
@@ -5,17 +5,17 @@ const JobDropDown = ({ selectedJobTabs, handleTabChange }) => {
   ]
 
   return (
-    <div className='flex mr-2 gap-x-3'>
+    <div className='inline-flex items-center bg-gray-100 rounded-xl p-1 mr-4'>
       {tabs.map((tab) => (
         <button
           key={tab.value}
           onClick={() => handleTabChange(tab.value)}
           className={`
-            text-[15px] px-4 py-2 rounded-lg border transition-all duration-200
+            relative px-5 py-2 text-sm rounded-lg transition-all
             ${
               selectedJobTabs === tab.value
-                ? 'bg-main-pink text-white font-semibold border-main-pink shadow-md'
-                : 'bg-white text-dark-gray font-medium border-gray-300 hover:bg-gray-100'
+                ? 'bg-white text-main-pink shadow-sm font-bold'
+                : 'text-gray-600 hover:text-dark-gray font-medium '
             }
           `}
         >

--- a/src/domains/main/common/components/BestList.jsx
+++ b/src/domains/main/common/components/BestList.jsx
@@ -6,7 +6,7 @@ const BestList = ({ boardName, bestList }) => {
 
   return (
     <div className='flex flex-col w-full sm:max-w-[940px]'>
-      <div className='flex items-center sm:mb-12 mb-7'>
+      <div className='flex items-center sm:mb-7 mb-5'>
         <video
           className="w-6 h-6 mr-1 sm:mr-2 sm:w-11 sm:h-11 bg-transparent bg-[url('https://cdn-icons-png.flaticon.com/512/17702/17702145.png')] bg-center bg-contain bg-no-repeat"
           preload='auto'


### PR DESCRIPTION
## #️⃣연관된 이슈

#379 

### 📝작업 내용
- 메인페이지 간격 수정
- 구인 & 구직 탭 디자인 수정

### 📸 스크린샷 (선택)

<img width="1017" height="283" alt="스크린샷 2025-10-02 오후 10 11 44" src="https://github.com/user-attachments/assets/a316ae2b-b0b4-42d1-8e74-68b2ad9265d8" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 스타일
  * 잡 드롭다운 UI 정제: 컨테이너를 inline-flex로 전환하고 배경, 패딩, 라운드, 마진 적용.
  * 버튼 기본 스타일을 컴팩트하게 조정하고 정렬 개선, 전환 효과 유지.
  * 활성 탭을 흰 배경+핑크 텍스트+그림자 중심으로 단순화해 가독성 강화.
  * 비활성 탭에 회색 계열 텍스트와 호버 대비를 적용해 상태 구분 향상.
  * 베스트 리스트 헤더 하단 마진 축소로 상단 영역 밀도 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->